### PR TITLE
CORE: SparkUCX memory pool + common RPC classes.

### DIFF
--- a/src/main/java/org/apache/spark/shuffle/ucx/UnsafeUtils.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/UnsafeUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.apache.spark.shuffle.ucx;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.nio.ch.FileChannelImpl;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+
+/**
+ * Java's native mmap functionality, that allows to mmap files > 2GB.
+ */
+public class UnsafeUtils {
+  private static final Method mmap;
+  private static final Method unmmap;
+  private static final Logger logger = LoggerFactory.getLogger(UnsafeUtils.class);
+
+  private static final Constructor<?> directBufferConstructor;
+
+  static {
+    try {
+      mmap = FileChannelImpl.class.getDeclaredMethod("map0", int.class, long.class, long.class);
+      mmap.setAccessible(true);
+      unmmap = FileChannelImpl.class.getDeclaredMethod("unmap0", long.class, long.class);
+      unmmap.setAccessible(true);
+      Class<?> classDirectByteBuffer = Class.forName("java.nio.DirectByteBuffer");
+      directBufferConstructor = classDirectByteBuffer.getDeclaredConstructor(long.class, int.class);
+      directBufferConstructor.setAccessible(true);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private UnsafeUtils() {}
+
+  public static ByteBuffer mmap(FileChannel fileChannel, long offset, long length) {
+    try {
+      long mapAddress = (long)mmap.invoke(fileChannel, 1, offset, length);
+      return getByteBuffer(mapAddress, (int)length);
+    } catch (IllegalAccessException | InvocationTargetException | IOException e) {
+      logger.error("MMap({}, {}) failed: {}", offset, length, e.getMessage());
+    }
+    return null;
+  }
+
+  public static void munmap(long address, long length) {
+    try {
+      unmmap.invoke(null, address, length);
+    } catch (IllegalAccessException | InvocationTargetException e) {
+      logger.error(e.getMessage());
+    }
+  }
+
+  private static ByteBuffer getByteBuffer(long address, int length) throws IOException {
+    try {
+      return (ByteBuffer)directBufferConstructor.newInstance(address, length);
+    } catch (InvocationTargetException ex) {
+      throw new IOException("java.nio.DirectByteBuffer: " +
+        "InvocationTargetException: " + ex.getTargetException());
+    } catch (Exception e) {
+      throw new IOException("java.nio.DirectByteBuffer exception: " + e.toString());
+    }
+  }
+}

--- a/src/main/java/org/apache/spark/shuffle/ucx/memory/MemoryPool.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/memory/MemoryPool.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.apache.spark.shuffle.ucx.memory;
+
+import org.apache.spark.shuffle.UcxShuffleConf;
+import org.apache.spark.unsafe.Platform;
+import org.openucx.jucx.ucp.UcpContext;
+import org.openucx.jucx.ucp.UcpMemory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Utility class to reuse and preallocate registered memory to avoid memory allocation
+ * and registration during shuffle phase.
+ */
+public class MemoryPool implements Closeable {
+  private static final Logger logger = LoggerFactory.getLogger(MemoryPool.class);
+
+  @Override
+  public void close() {
+    for (AllocatorStack stack: allocStackMap.values()) {
+      stack.close();
+      logger.info("Stack of size {}. " +
+          "Total requests: {}, total allocations: {}, preAllocations: {}",
+        stack.length, stack.totalRequests.get(), stack.totalAlloc.get(), stack.preAllocs.get());
+    }
+    allocStackMap.clear();
+  }
+
+  private class AllocatorStack implements Closeable {
+    private final AtomicInteger totalRequests = new AtomicInteger(0);
+    private final AtomicInteger totalAlloc = new AtomicInteger(0);
+    private final AtomicInteger preAllocs = new AtomicInteger(0);
+    private final ConcurrentLinkedDeque<RegisteredMemory> stack = new ConcurrentLinkedDeque<>();
+    private final int length;
+
+    private AllocatorStack(int length) {
+      this.length = length;
+    }
+
+    private RegisteredMemory get() {
+      RegisteredMemory result = stack.pollFirst();
+      if (result == null) {
+        if (length < conf.minRegistrationSize()) {
+          int numBuffers = conf.minRegistrationSize() / length;
+          logger.debug("Allocating {} buffers of size {}", numBuffers, length);
+          preallocate(numBuffers);
+          result = stack.pollFirst();
+          if (result == null) {
+            return get();
+          } else {
+            result.getRefCount().incrementAndGet();
+          }
+        } else {
+          ByteBuffer buffer = malloc(length);
+          UcpMemory memory = register(buffer);
+          result = new RegisteredMemory(new AtomicInteger(1), memory, buffer);
+          totalAlloc.incrementAndGet();
+        }
+      } else {
+        result.getRefCount().incrementAndGet();
+      }
+      totalRequests.incrementAndGet();
+      return result;
+    }
+
+    private void put(RegisteredMemory registeredMemory) {
+      registeredMemory.getRefCount().decrementAndGet();
+      stack.addLast(registeredMemory);
+    }
+
+    private ByteBuffer malloc(int size) {
+      return Platform.allocateDirectBuffer(size);
+    }
+
+    private UcpMemory register(ByteBuffer buffer) {
+      UcpMemory memory = null;
+      if (conf.preregisterMemory()) {
+        memory = context.registerMemory(buffer);
+      }
+      return memory;
+    }
+
+    private void preallocate(int numBuffers) {
+      // Platform.allocateDirectBuffer supports only 2GB of buffer.
+      // Decrease number of buffers if total size of preAllocation > 2GB.
+      if ((long)length * (long)numBuffers > Integer.MAX_VALUE) {
+        numBuffers = Integer.MAX_VALUE / length;
+      }
+
+      ByteBuffer buffer = malloc(numBuffers * length);
+      UcpMemory memory = register(buffer);
+      AtomicInteger refCount = new AtomicInteger(numBuffers);
+      for (int i = 0; i < numBuffers; i++) {
+        buffer.position(i * length).limit(i * length + length);
+        final ByteBuffer slice = buffer.slice();
+        RegisteredMemory registeredMemory = new RegisteredMemory(refCount, memory, slice);
+        put(registeredMemory);
+      }
+      preAllocs.incrementAndGet();
+      totalAlloc.incrementAndGet();
+    }
+
+    @Override
+    public void close() {
+      while (!stack.isEmpty()) {
+        RegisteredMemory memory = stack.pollFirst();
+        if (memory != null) {
+          memory.deregisterNativeMemory();
+        }
+      }
+    }
+  }
+
+  private final ConcurrentHashMap<Integer, AllocatorStack> allocStackMap =
+    new ConcurrentHashMap<>();
+  private final UcpContext context;
+  private final UcxShuffleConf conf;
+
+  public MemoryPool(UcpContext context, UcxShuffleConf conf) {
+    this.context = context;
+    this.conf = conf;
+  }
+
+  private long roundUpToTheNextPowerOf2(long length) {
+    // Round up length to the nearest power of two, or the minimum block size
+    if (length < conf.minBufferSize()) {
+      length = conf.minBufferSize();
+    } else {
+      length--;
+      length |= length >> 1;
+      length |= length >> 2;
+      length |= length >> 4;
+      length |= length >> 8;
+      length |= length >> 16;
+      length++;
+    }
+    return length;
+  }
+
+  public RegisteredMemory get(int size) {
+    long roundedSize = roundUpToTheNextPowerOf2(size);
+    assert roundedSize < Integer.MAX_VALUE && roundedSize > 0;
+    AllocatorStack stack =
+      allocStackMap.computeIfAbsent((int)roundedSize, AllocatorStack::new);
+    RegisteredMemory result = stack.get();
+    result.getBuffer().position(0).limit(size);
+    return result;
+  }
+
+  public void put(RegisteredMemory memory) {
+    AllocatorStack allocatorStack = allocStackMap.get(memory.getBuffer().capacity());
+    if (allocatorStack != null) {
+      allocatorStack.put(memory);
+    }
+  }
+
+  public void preAlocate() {
+    conf.preallocateBuffersMap().forEach((size, numBuffers) -> {
+      logger.debug("Pre allocating {} buffers of size {}", numBuffers, size);
+      AllocatorStack stack = new AllocatorStack(size);
+      allocStackMap.put(size, stack);
+      stack.preallocate(numBuffers);
+    });
+  }
+
+}

--- a/src/main/java/org/apache/spark/shuffle/ucx/memory/RegisteredMemory.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/memory/RegisteredMemory.java
@@ -1,0 +1,43 @@
+package org.apache.spark.shuffle.ucx.memory;
+
+import org.openucx.jucx.ucp.UcpMemory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Structure to use 1 memory region for multiple ByteBuffers.
+ * Keeps track on reference count to memory region.
+ */
+public class RegisteredMemory {
+  private static final Logger logger = LoggerFactory.getLogger(RegisteredMemory.class);
+
+  private final AtomicInteger refcount;
+  private final UcpMemory memory;
+  private final ByteBuffer buffer;
+
+  RegisteredMemory(AtomicInteger refcount, UcpMemory memory, ByteBuffer buffer) {
+    this.refcount = refcount;
+    this.memory = memory;
+    this.buffer = buffer;
+  }
+
+  public ByteBuffer getBuffer() {
+    return buffer;
+  }
+
+  AtomicInteger getRefCount() {
+    return refcount;
+  }
+
+  void deregisterNativeMemory() {
+    if (refcount.get() != 0) {
+      logger.warn("De-registering memory that has active references.");
+    }
+    if (memory != null && memory.getNativeId() != null) {
+      memory.deregister();
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/shuffle/UcxShuffleConf.scala
+++ b/src/main/scala/org/apache/spark/shuffle/UcxShuffleConf.scala
@@ -1,0 +1,57 @@
+/*
+* Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+package org.apache.spark.shuffle
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.SparkConf
+import org.apache.spark.internal.config.ConfigBuilder
+import org.apache.spark.network.util.ByteUnit
+import org.apache.spark.util.Utils
+
+/**
+ * Plugin configuration properties.
+ */
+class UcxShuffleConf(conf: SparkConf) extends SparkConf {
+  private def getUcxConf(name: String) = s"spark.shuffle.ucx.$name"
+
+  // Memory Pool
+  private lazy val PREALLOCATE_BUFFERS =
+  ConfigBuilder(getUcxConf("memory.preAllocateBuffers"))
+    .doc("Comma separated list of buffer size : buffer count pairs to preallocate in memory pool. E.g. 4k:1000,16k:500")
+    .stringConf.createWithDefault("")
+
+  lazy val preallocateBuffersMap: java.util.Map[java.lang.Integer, java.lang.Integer] = {
+    conf.get(PREALLOCATE_BUFFERS).split(",").withFilter(s => !s.isEmpty)
+      .map(entry => entry.split(":") match {
+        case Array(bufferSize, bufferCount) =>
+          (int2Integer(Utils.byteStringAsBytes(bufferSize.trim).toInt),
+           int2Integer(bufferCount.toInt))
+      }).toMap.asJava
+  }
+
+  private lazy val MIN_BUFFER_SIZE = ConfigBuilder(getUcxConf("memory.minBufferSize"))
+    .doc("Minimal buffer size in memory pool.")
+    .bytesConf(ByteUnit.BYTE)
+    .createWithDefault(1024)
+
+  lazy val minBufferSize: Long = conf.getSizeAsBytes(MIN_BUFFER_SIZE.key,
+    MIN_BUFFER_SIZE.defaultValueString)
+
+  private lazy val MIN_REGISTRATION_SIZE =
+    ConfigBuilder(getUcxConf("memory.minAllocationSize"))
+    .doc("Minimal memory registration size in memory pool.")
+    .bytesConf(ByteUnit.MiB)
+    .createWithDefault(4)
+
+  lazy val minRegistrationSize: Int = conf.getSizeAsBytes(MIN_REGISTRATION_SIZE.key,
+    MIN_REGISTRATION_SIZE.defaultValueString).toInt
+
+  private lazy val PREREGISTER_MEMORY = ConfigBuilder(getUcxConf("memory.preregister"))
+    .doc("Whether to do ucp mem map for allocated memory in memory pool")
+    .booleanConf.createWithDefault(true)
+
+  lazy val preregisterMemory: Boolean = conf.getBoolean(PREREGISTER_MEMORY.key, PREREGISTER_MEMORY.defaultValue.get)
+}


### PR DESCRIPTION
1. UcxShuffleConf class - to get SparkUCX configuration.
2. Memory pool class - memory pool implementation to avoid allocation in the data exchange path. Basically memory pool is a map of size -> buffer list. E.g.:
[4kb] -> [buffer1]->[buffer2]->[buffer3]...
TODO: LRU cleaning? 
3. Unsafe utils class - to be able to do mmaping files > 2GB and explicitly unmaping rather then relying on java's GC.