### PR TITLE
[CORE] UcxNode implementation - coordination point for ucp operations.

### DIFF
--- a/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.apache.spark.shuffle.ucx;
+
+import org.apache.spark.SparkEnv;
+import org.apache.spark.shuffle.UcxShuffleConf;
+import org.apache.spark.shuffle.UcxWorkerWrapper;
+import org.apache.spark.shuffle.ucx.memory.MemoryPool;
+import org.apache.spark.shuffle.ucx.memory.RegisteredMemory;
+import org.apache.spark.shuffle.ucx.rpc.SerializableBlockManagerID;
+import org.apache.spark.shuffle.ucx.rpc.UcxListenerThread;
+import org.apache.spark.storage.BlockManagerId;
+import org.openucx.jucx.UcxCallback;
+import org.openucx.jucx.UcxException;
+import org.openucx.jucx.UcxRequest;
+import org.openucx.jucx.ucp.*;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Single instance class per spark process, that keeps UcpContext, memory and worker pools.
+ */
+public class UcxNode implements Closeable {
+  // Global
+  private static final Logger logger = LoggerFactory.getLogger(UcxNode.class);
+  private final boolean isDriver;
+  private final UcpContext context;
+  private final MemoryPool memoryPool;
+  private final UcpWorkerParams workerParams = new UcpWorkerParams().requestThreadSafety();
+  private final UcpWorker globalWorker;
+  private final UcxShuffleConf conf;
+  // Mapping from spark's entity of BlockManagerId to UcxEntity workerAddress.
+  private static final ConcurrentHashMap<BlockManagerId, ByteBuffer> workerAdresses =
+    new ConcurrentHashMap<>();
+  private final Thread listenerProgressThread;
+  private boolean closed = false;
+
+  // Driver
+  private UcpListener listener;
+  // Mapping from UcpEndpoint to ByteBuffer of RPC message, to introduce executor to cluster
+  private static final ConcurrentHashMap<UcpEndpoint, ByteBuffer> rpcConnections =
+    new ConcurrentHashMap<>();
+
+  // Executor
+  private UcpEndpoint globalDriverEndpoint;
+  // Keep track of allocated workers to correctly close them.
+  private static final Set<UcxWorkerWrapper> allocatedWorkers = ConcurrentHashMap.newKeySet();
+  private final ThreadLocal<UcxWorkerWrapper> threadLocalWorker;
+
+  public UcxNode(UcxShuffleConf conf, boolean isDriver) {
+    this.conf = conf;
+    this.isDriver = isDriver;
+    UcpParams params = new UcpParams().requestTagFeature()
+      .requestRmaFeature().requestWakeupFeature()
+      .setMtWorkersShared(true);
+    context = new UcpContext(params);
+    memoryPool = new MemoryPool(context, conf);
+    globalWorker = context.newWorker(workerParams);
+    InetSocketAddress driverAddress = new InetSocketAddress(conf.driverHost(), conf.driverPort());
+
+    if (isDriver) {
+      startDriver(driverAddress);
+    } else {
+      startExecutor(driverAddress);
+    }
+
+    // Global listener thread, that keeps lazy progress for connection establishment
+    listenerProgressThread = new UcxListenerThread(this, isDriver);
+    listenerProgressThread.start();
+
+    if (!isDriver) {
+      memoryPool.preAlocate();
+    }
+
+    threadLocalWorker = ThreadLocal.withInitial(() -> {
+      UcpWorker localWorker = context.newWorker(workerParams);
+      UcxWorkerWrapper result = new UcxWorkerWrapper(localWorker,
+        conf, allocatedWorkers.size());
+      if (result.id() > conf.coresPerProcess()) {
+        logger.warn("Thread: {} - creates new worker {} > numCores",
+          Thread.currentThread().getId(), result.id());
+      }
+      allocatedWorkers.add(result);
+      return result;
+    });
+  }
+
+  private void startDriver(InetSocketAddress driverAddress) {
+    // 1. Start listener on a driver and accept RPC messages from executors with their
+    // worker addresses
+    UcpListenerParams listenerParams = new UcpListenerParams().setSockAddr(driverAddress);
+    listener = globalWorker.newListener(listenerParams);
+    logger.info("Started UcxNode on {}", driverAddress);
+  }
+
+  /**
+   * Allocates ByteBuffer from memoryPool and serializes there workerAddress,
+   * followed by BlockManagerID
+   * @return RegisteredMemory that holds metadata buffer.
+   */
+  private RegisteredMemory buildMetadataBuffer() {
+    BlockManagerId blockManagerId = SparkEnv.get().blockManager().blockManagerId();
+    ByteBuffer workerAddresss = globalWorker.getAddress();
+
+    RegisteredMemory metadataMemory = memoryPool.get(conf.metadataRPCBufferSize());
+    ByteBuffer metadataBuffer = metadataMemory.getBuffer();
+    metadataBuffer.order(ByteOrder.nativeOrder());
+    metadataBuffer.putInt(workerAddresss.capacity());
+    metadataBuffer.put(workerAddresss);
+    try {
+      SerializableBlockManagerID.serializeBlockManagerID(blockManagerId, metadataBuffer);
+    } catch (IOException e) {
+      String errorMsg = String.format("Failed to serialize %s: %s", blockManagerId,
+        e.getMessage());
+      throw new UcxException(errorMsg);
+    }
+    metadataBuffer.clear();
+    return metadataMemory;
+  }
+
+  private void startExecutor(InetSocketAddress driverAddress) {
+    // 1. Executor: connect to driver using sockaddr
+    // and send it's worker address followed by BlockManagerID.
+    globalDriverEndpoint = globalWorker.newEndpoint(
+      new UcpEndpointParams().setSocketAddress(driverAddress).setPeerErrorHadnlingMode()
+    );
+
+    RegisteredMemory metadataMemory = buildMetadataBuffer();
+    // TODO: send using stream API when it would be available in jucx.
+    globalDriverEndpoint.sendTaggedNonBlocking(metadataMemory.getBuffer(), new UcxCallback() {
+      @Override
+      public void onSuccess(UcxRequest request) {
+        memoryPool.put(metadataMemory);
+      }
+    });
+  }
+
+  public UcxShuffleConf getConf() {
+    return conf;
+  }
+
+  public UcpWorker getGlobalWorker() {
+    return globalWorker;
+  }
+
+  public MemoryPool getMemoryPool() {
+    return memoryPool;
+  }
+
+  public UcpContext getContext() {
+    return context;
+  }
+
+  /**
+   * Get or initialize worker for current thread
+   */
+  public UcxWorkerWrapper getThreadLocalWorker() {
+    return threadLocalWorker.get();
+  }
+
+  public static ConcurrentMap<BlockManagerId, ByteBuffer> getWorkerAddresses() {
+    return workerAdresses;
+  }
+
+  public static ConcurrentMap<UcpEndpoint, ByteBuffer> getRpcConnections() {
+    return rpcConnections;
+  }
+
+  private void stopDriver() {
+    listener.close();
+    listener = null;
+    rpcConnections.keySet().forEach(UcpEndpoint::close);
+    rpcConnections.clear();
+  }
+
+  private void stopExecutor() {
+    globalDriverEndpoint.close();
+    allocatedWorkers.forEach(UcxWorkerWrapper::close);
+    allocatedWorkers.clear();
+  }
+
+  @Override
+  public void close() {
+    threadLocalWorker.remove();
+    synchronized (this) {
+      if (!closed) {
+        logger.info("Stopping UcxNode");
+        listenerProgressThread.interrupt();
+        try {
+          listenerProgressThread.join();
+        } catch (InterruptedException e) {
+          logger.error(e.getMessage());
+          Thread.currentThread().interrupt();
+        }
+
+        if (isDriver) {
+          stopDriver();
+        } else {
+          stopExecutor();
+        }
+
+        globalWorker.signal();
+        memoryPool.close();
+        globalWorker.close();
+        context.close();
+        closed = true;
+      }
+    }
+  }
+}

--- a/src/main/java/org/apache/spark/shuffle/ucx/rpc/RpcConnectionCallback.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/rpc/RpcConnectionCallback.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.apache.spark.shuffle.ucx.rpc;
+
+import org.apache.spark.shuffle.ucx.UcxNode;
+import org.apache.spark.storage.BlockManagerId;
+import org.apache.spark.unsafe.Platform;
+import org.openucx.jucx.UcxCallback;
+import org.openucx.jucx.UcxException;
+import org.openucx.jucx.UcxRequest;
+import org.openucx.jucx.ucp.UcpEndpoint;
+import org.openucx.jucx.ucp.UcpEndpointParams;
+import org.openucx.jucx.ucp.UcpWorker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * RPC processing logic. Both driver and excutor accepts the same RPC messgae:
+ * executor worker address followed by it's serialized BlockManagerID.
+ * Executor on accepting this message just adds workerAddress to the connection map.
+ * Driver doing the logic of introducing connected executor to cluster nodes and
+ * introduce cluster to connected executor.
+ */
+public class RpcConnectionCallback extends UcxCallback {
+  private static final Logger logger = LoggerFactory.getLogger(RpcConnectionCallback.class);
+  private final ByteBuffer metadataBuffer;
+  private final boolean isDriver;
+  private final UcxNode ucxNode;
+  private static final ConcurrentMap<UcpEndpoint, ByteBuffer> rpcConnections =
+    UcxNode.getRpcConnections();
+  private static final ConcurrentMap<BlockManagerId, ByteBuffer> workerAdresses =
+    UcxNode.getWorkerAddresses();
+
+  RpcConnectionCallback(ByteBuffer metadataBuffer, boolean isDriver, UcxNode ucxNode) {
+    this.metadataBuffer = metadataBuffer;
+    this.isDriver = isDriver;
+    this.ucxNode = ucxNode;
+  }
+
+  @Override
+  public void onSuccess(UcxRequest request) {
+    int workerAddressSize = metadataBuffer.getInt();
+    ByteBuffer workerAddress = Platform.allocateDirectBuffer(workerAddressSize);
+
+    // Copy worker address from metadata buffer to separate buffer.
+    final ByteBuffer metadataView = metadataBuffer.duplicate();
+    metadataView.limit(metadataView.position() + workerAddressSize);
+    workerAddress.put(metadataView);
+    metadataBuffer.position(metadataBuffer.position() + workerAddressSize);
+
+    BlockManagerId blockManagerId;
+    try {
+      blockManagerId = SerializableBlockManagerID
+        .deserializeBlockManagerID(metadataBuffer);
+    } catch (IOException e) {
+      String errorMsg = String.format("Failed to deserialize BlockManagerId: %s", e.getMessage());
+      throw new UcxException(errorMsg);
+    }
+    logger.debug("Received RPC message from {}", blockManagerId);
+    UcpWorker globalWorker = ucxNode.getGlobalWorker();
+
+    workerAddress.clear();
+
+    if (isDriver) {
+      metadataBuffer.clear();
+      UcpEndpoint newConnection = globalWorker.newEndpoint(
+        new UcpEndpointParams().setPeerErrorHadnlingMode()
+          .setUcpAddress(workerAddress));
+      // For each existing connection
+      rpcConnections.forEach((connection, connectionMetadata) -> {
+        // send address of joined worker to already connected workers
+        connection.sendTaggedNonBlocking(metadataBuffer, null);
+        // introduce other workers to joined worker
+        newConnection.sendTaggedNonBlocking(connectionMetadata, null);
+      });
+
+      rpcConnections.put(newConnection, metadataBuffer);
+    }
+    workerAdresses.put(blockManagerId, workerAddress);
+    synchronized (workerAdresses) {
+      workerAdresses.notifyAll();
+    }
+  }
+}

--- a/src/main/java/org/apache/spark/shuffle/ucx/rpc/SerializableBlockManagerID.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/rpc/SerializableBlockManagerID.java
@@ -1,0 +1,32 @@
+package org.apache.spark.shuffle.ucx.rpc;
+
+import com.esotericsoftware.kryo.io.ByteBufferInputStream;
+import com.esotericsoftware.kryo.io.ByteBufferOutputStream;
+import org.apache.spark.storage.BlockManagerId;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Static mthods to serialize BlockManagerID to ByteBuffer.
+ */
+public class SerializableBlockManagerID {
+
+  public static void serializeBlockManagerID(BlockManagerId blockManagerId,
+                                             ByteBuffer metadataBuffer) throws IOException {
+    ObjectOutputStream oos = new ObjectOutputStream(
+      new ByteBufferOutputStream(metadataBuffer));
+    blockManagerId.writeExternal(oos);
+    oos.close();
+  }
+
+  static BlockManagerId deserializeBlockManagerID(ByteBuffer metadataBuffer) throws IOException {
+    ObjectInputStream ois =
+      new ObjectInputStream(new ByteBufferInputStream(metadataBuffer));
+    BlockManagerId blockManagerId = BlockManagerId.apply(ois);
+    ois.close();
+    return blockManagerId;
+  }
+}

--- a/src/main/java/org/apache/spark/shuffle/ucx/rpc/UcxListenerThread.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/rpc/UcxListenerThread.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.apache.spark.shuffle.ucx.rpc;
+
+import org.apache.spark.shuffle.ucx.UcxNode;
+import org.apache.spark.unsafe.Platform;
+import org.openucx.jucx.UcxRequest;
+import org.openucx.jucx.ucp.UcpWorker;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * Thread for progressing global worker for connection establishment and RPC exchange.
+ */
+public class UcxListenerThread extends Thread implements Runnable {
+  private UcxNode ucxNode;
+  private boolean isDriver;
+  private final UcpWorker globalWorker;
+
+  public UcxListenerThread(UcxNode ucxNode, boolean isDriver) {
+    this.ucxNode = ucxNode;
+    this.isDriver = isDriver;
+    this.globalWorker = ucxNode.getGlobalWorker();
+    setDaemon(true);
+    setName("UcxListenerThread");
+  }
+
+  /**
+   * 2. Both Driver and Executor. Accept Recv request.
+   * If on driver broadcast it to other executors. On executor just save worker addresses.
+   */
+  private UcxRequest recvRequest() {
+    ByteBuffer metadataBuffer = Platform.allocateDirectBuffer(
+      ucxNode.getConf().metadataRPCBufferSize());
+    metadataBuffer.order(ByteOrder.nativeOrder());
+    RpcConnectionCallback callback = new RpcConnectionCallback(metadataBuffer, isDriver, ucxNode);
+    return globalWorker.recvTaggedNonBlocking(metadataBuffer, callback);
+  }
+
+  @Override
+  public void run() {
+    UcxRequest recv = recvRequest();
+    while (!isInterrupted()) {
+      if (recv.isCompleted()) {
+        // Process 1 recv request at a time.
+        // TODO: cancel this request at exit when would be implemented.
+        recv = recvRequest();
+      }
+      if (globalWorker.progress() == 0) {
+        globalWorker.waitForEvents();
+      }
+    }
+  }
+}

--- a/src/main/scala/org/apache/spark/shuffle/UcxWorkerWrapper.scala
+++ b/src/main/scala/org/apache/spark/shuffle/UcxWorkerWrapper.scala
@@ -1,0 +1,97 @@
+/*
+* Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+package org.apache.spark.shuffle
+
+import java.io.Closeable
+import java.net.InetSocketAddress
+import java.nio.ByteBuffer
+import java.util.concurrent.LinkedBlockingQueue
+
+import scala.collection.JavaConverters._
+
+import scala.collection.mutable
+import scala.util.Try
+
+import org.openucx.jucx.{UcxException, UcxRequest}
+import org.openucx.jucx.ucp.{UcpEndpoint, UcpEndpointParams, UcpRemoteKey, UcpWorker}
+import org.apache.spark.SparkEnv
+import org.apache.spark.internal.Logging
+import org.apache.spark.shuffle.ucx.UcxNode
+import org.apache.spark.storage.{BlockManager, BlockManagerId}
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.util.Utils
+
+/**
+ * Worker per thread wrapper, that maintains connection and progress logic.
+ */
+class UcxWorkerWrapper(val worker: UcpWorker, val conf: UcxShuffleConf, val id: Int)
+  extends Closeable with Logging {
+  type ShuffleId = Int
+  type MapId = Int
+
+  private final val driverSocketAddress = new InetSocketAddress(conf.driverHost, conf.driverPort)
+  private final val endpointParams = new UcpEndpointParams().setSocketAddress(driverSocketAddress)
+    .setPeerErrorHadnlingMode()
+  val driverEndpoint: UcpEndpoint = worker.newEndpoint(endpointParams)
+
+  val blockManager: BlockManager = SparkEnv.get.blockManager
+
+  private final val connections = mutable.Map.empty[BlockManagerId, UcpEndpoint]
+
+  override def close(): Unit = {
+    driverEndpoint.close()
+    worker.close()
+  }
+
+  /**
+   * Progress single request until it's not completed.
+   */
+  def progressRequest(request: UcxRequest): Unit = {
+    val startTime = System.currentTimeMillis()
+    while (!request.isCompleted) {
+      progress()
+    }
+    logDebug(s"Request completed in ${Utils.getUsedTimeMs(startTime)}")
+  }
+
+  /**
+   * The only place for worker progress
+   */
+  private def progress(): Int = {
+    worker.progress()
+  }
+
+  /**
+   * Establish connections to known instances.
+   */
+  def preconnnect(): Unit = {
+    UcxNode.getWorkerAddresses.keySet().asScala.foreach(getConnection)
+  }
+
+  def getConnection(blockManagerId: BlockManagerId): UcpEndpoint = {
+    val workerAdresses = UcxNode.getWorkerAddresses
+    // Block untill there's no worker address for this BlockManagerID
+    val startTime = System.currentTimeMillis()
+    val timeout = conf.getTimeAsMs("spark.network.timeout")
+    if (workerAdresses.get(blockManagerId) == null) {
+      workerAdresses.synchronized {
+        while (workerAdresses.get(blockManagerId) == null) {
+          workerAdresses.wait(timeout)
+          if (System.currentTimeMillis() - startTime > timeout) {
+            throw new UcxException(s"Didn't get worker address for $blockManagerId during $timeout")
+          }
+        }
+      }
+    }
+
+    connections.getOrElseUpdate(blockManagerId, {
+      logInfo(s"Worker $id connecting to $blockManagerId")
+      val endpointParams = new UcpEndpointParams()
+        .setPeerErrorHadnlingMode()
+        .setUcpAddress(workerAdresses.get(blockManagerId))
+     worker.newEndpoint(endpointParams)
+    })
+  }
+}


### PR DESCRIPTION
UcxNode implementation, coordination point for Ucx operations:

1. Creates and closes single UcpContext.
2. Instantiates memory pool for context.
3. On driver start listener to exchange RPC with executors.
4. On Executor creates globalWorker
5. On Executor creates globalEndpoint for RPC (using listener address for driver) and sends globalWorker workerAddress.
6. On driver when it got RPC message it introduces executor to already joined executors + send to joined executor addresses of other cluster members.
7. On Executor creates ThreadLocal worker pool, that makes sure we're using worker per thread model.
8. Releases all resources on exit. 