### PR TITLE
[CORE] UcxShuffleManager implementation.

### DIFF
--- a/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
@@ -198,6 +198,7 @@ public class UcxNode implements Closeable {
       if (!closed) {
         logger.info("Stopping UcxNode");
         listenerProgressThread.interrupt();
+        globalWorker.signal();
         try {
           listenerProgressThread.join();
         } catch (InterruptedException e) {
@@ -211,7 +212,6 @@ public class UcxNode implements Closeable {
           stopExecutor();
         }
 
-        globalWorker.signal();
         memoryPool.close();
         globalWorker.close();
         context.close();

--- a/src/main/java/org/apache/spark/shuffle/ucx/rpc/UcxRemoteMemory.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/rpc/UcxRemoteMemory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.apache.spark.shuffle.ucx.rpc;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.nio.ByteBuffer;
+
+/**
+ * Utility class to serialize / deserialize metadata buffer on a driver.
+ * Needed to propagate metadata buffer information to executors using
+ * spark's mechanism to broadcast tasks.
+ */
+public class UcxRemoteMemory implements Serializable {
+  private long address;
+  private ByteBuffer rkeyBuffer;
+
+  public UcxRemoteMemory(long address, ByteBuffer rkeyBuffer) {
+    this.address = address;
+    this.rkeyBuffer = rkeyBuffer;
+  }
+
+  public UcxRemoteMemory() {}
+
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    out.writeLong(address);
+    out.writeInt(rkeyBuffer.limit());
+    byte[] copy = new byte[rkeyBuffer.limit()];
+    rkeyBuffer.clear();
+    rkeyBuffer.get(copy);
+    out.write(copy);
+  }
+
+  private void readObject(ObjectInputStream in) throws IOException {
+    this.address = in.readLong();
+    int bufferSize = in.readInt();
+    byte[] buffer = new byte[bufferSize];
+    in.read(buffer, 0, bufferSize);
+    this.rkeyBuffer = ByteBuffer.allocateDirect(bufferSize).put(buffer);
+    this.rkeyBuffer.clear();
+  }
+}

--- a/src/main/scala/org/apache/spark/shuffle/UcxShuffleConf.scala
+++ b/src/main/scala/org/apache/spark/shuffle/UcxShuffleConf.scala
@@ -28,6 +28,17 @@ class UcxShuffleConf(conf: SparkConf) extends SparkConf {
   lazy val driverPort: Int = conf.getInt(getUcxConf("driver.port"), 55443)
 
   // Metadata
+
+  private lazy val RKEY_SIZE: ConfigEntry[Long] =
+  ConfigBuilder(getUcxConf("rkeySize"))
+    .doc("Maximum size of rKeyBuffer")
+    .bytesConf(ByteUnit.BYTE)
+    .createWithDefault(150)
+
+  // For metadata we publish index file + data file rkeys
+  lazy val metadataBlockSize: Long = 2 * conf.getSizeAsBytes(RKEY_SIZE.key,
+    RKEY_SIZE.defaultValueString)
+
   private lazy val METADATA_RPC_BUFFER_SIZE =
     ConfigBuilder(getUcxConf("rpc.metadata.bufferSize"))
       .doc("Buffer size of worker -> driver metadata message")

--- a/src/main/scala/org/apache/spark/shuffle/UcxShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/UcxShuffleManager.scala
@@ -1,0 +1,147 @@
+/*
+* Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+package org.apache.spark.shuffle
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.JavaConverters._
+
+import org.openucx.jucx.ucp.UcpMemory
+import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
+import org.apache.spark.shuffle.sort.{BypassMergeSortShuffleHandle, SerializedShuffleHandle, SortShuffleManager, SortShuffleWriter}
+import org.apache.spark.shuffle.ucx.UcxNode
+import org.apache.spark.shuffle.ucx.rpc.UcxRemoteMemory
+import org.apache.spark.unsafe.Platform
+import org.apache.spark.util.ShutdownHookManager
+
+/**
+ * Main entry point of Ucx shuffle plugin. It extends spark's default SortShufflePlugin
+ * and injects needed logic in override methods.
+ */
+class UcxShuffleManager(val conf: SparkConf, isDriver: Boolean) extends SortShuffleManager(conf) {
+  type ShuffleId = Int
+  type MapId = Int
+
+  val ucxShuffleConf = new UcxShuffleConf(conf)
+  var ucxNode: UcxNode = _
+
+  ShutdownHookManager.addShutdownHook(Int.MaxValue - 1)(stop)
+
+  /**
+   * Mapping between shuffle and metadata buffer, to deregister it when shuffle not needed.
+   */
+  private val shuffleIdToMetadataBuffer =
+    new ConcurrentHashMap[ShuffleId, UcpMemory]().asScala
+
+  /**
+   * Atomically starts UcxNode singleton - one for all shuffle threads.
+   */
+  def startUcxNodeIfMissing(): Unit = synchronized {
+    if (ucxNode == null) {
+      ucxNode = new UcxNode(ucxShuffleConf, isDriver)
+    }
+  }
+
+  if (isDriver) {
+    startUcxNodeIfMissing()
+  }
+
+  /**
+   * Register a shuffle with the manager and obtain a handle for it to pass to tasks.
+   * Called on driver and guaranteed by spark that shuffle on executor will start after it.
+   */
+  override def registerShuffle[K, V, C](shuffleId: Int,
+                                        numMaps: Int,
+                                        dependency: ShuffleDependency[K, V, C]): ShuffleHandle = {
+    assume(isDriver)
+    // Register metadata buffer where each map will publish it's index and data file metadata
+    val metadataBufferSize = numMaps * ucxShuffleConf.metadataBlockSize
+    val metadataBuffer = Platform.allocateDirectBuffer(metadataBufferSize.toInt)
+
+    val metadataMemory = ucxNode.getContext.registerMemory(metadataBuffer)
+    shuffleIdToMetadataBuffer.put(shuffleId, metadataMemory)
+
+    val driverMemory = new UcxRemoteMemory(metadataMemory.getAddress,
+      metadataMemory.getRemoteKeyBuffer)
+
+    if (SortShuffleWriter.shouldBypassMergeSort(conf, dependency)) {
+      // If there are fewer than spark.shuffle.sort.bypassMergeThreshold partitions and we don't
+      // need map-side aggregation, then write numPartitions files directly and just concatenate
+      // them at the end. This avoids doing serialization and deserialization twice to merge
+      // together the spilled files, which would happen with the normal code path. The downside is
+      // having multiple files open at a time and thus more memory allocated to buffers.
+      new UcxBypassMergeSortShuffleHandle[K, V](driverMemory, shuffleId, numMaps,
+        dependency.asInstanceOf[ShuffleDependency[K, V, V]])
+    } else if (SortShuffleManager.canUseSerializedShuffle(dependency)) {
+      // Otherwise, try to buffer map outputs in a serialized form, since this is more efficient:
+      new UcxSerializedShuffleHandle[K, V](driverMemory, shuffleId, numMaps,
+        dependency.asInstanceOf[ShuffleDependency[K, V, V]])
+    } else {
+      // Otherwise, buffer map outputs in a deserialized form:
+      new UcxBaseShuffleHandle(driverMemory, shuffleId, numMaps, dependency)
+    }
+  }
+
+  /**
+   * Mapper callback on executor. Just start UcxNode and use Spark mapper logic.
+   */
+  override def getWriter[K, V](handle: ShuffleHandle, mapId: Int,
+                               context: TaskContext): ShuffleWriter[K, V] = {
+    startUcxNodeIfMissing()
+    super.getWriter(handle, mapId, context)
+  }
+
+  /**
+   * Reducer callback on executor.
+   */
+  override def getReader[K, C](handle: ShuffleHandle, startPartition: Int,
+                               endPartition: Int, context: TaskContext): ShuffleReader[K, C] = {
+    startUcxNodeIfMissing()
+    super.getReader(handle, startPartition, endPartition, context)
+  }
+
+
+  override def unregisterShuffle(shuffleId: Int): Boolean = {
+    shuffleIdToMetadataBuffer.remove(shuffleId).foreach(_.deregister())
+    super.unregisterShuffle(shuffleId)
+  }
+
+  /**
+   * Called on both driver and executors to finally cleanup resources.
+   */
+  override def stop(): Unit = synchronized {
+    logInfo("Stopping shuffle manager")
+    shuffleIdToMetadataBuffer.values.foreach(_.deregister())
+    shuffleIdToMetadataBuffer.clear()
+    if (ucxNode != null) {
+      ucxNode.close()
+      ucxNode = null
+    }
+    super.stop()
+  }
+
+}
+
+/**
+ * Spark shuffle handles extensions, broadcasted by TCP to executors.
+ * Added metadataBufferOnDriver field, that contains address and rkey of driver metadata buffer.
+ */
+class UcxBaseShuffleHandle[K, V, C](metadataBufferOnDriver: UcxRemoteMemory,
+                                    shuffleId: Int,
+                                    numMaps: Int,
+                                    dependency: ShuffleDependency[K, V, C])
+  extends BaseShuffleHandle[K, V, C](shuffleId, numMaps, dependency)
+
+class UcxSerializedShuffleHandle[K, V](metadataBufferOnDriver: UcxRemoteMemory,
+                                       shuffleId: Int,
+                                       numMaps: Int,
+                                       dependency: ShuffleDependency[K, V, V])
+  extends SerializedShuffleHandle[K, V](shuffleId, numMaps, dependency)
+
+class UcxBypassMergeSortShuffleHandle[K, V](metadataBufferOnDriver: UcxRemoteMemory,
+                                            shuffleId: Int,
+                                            numMaps: Int,
+                                            dependency: ShuffleDependency[K, V, V])
+  extends BypassMergeSortShuffleHandle(shuffleId, numMaps, dependency)


### PR DESCRIPTION
UcxShuffleManager - main entry point to the plugin. All logic would be implemented in 3 callbacks:
1. `registerShuffle` - called on a driver. Indicates that this job would have a shuffle. Driver allocates metadata buffer, so mappers can publish data and index file addresses and keys.
2. `shuffleBlockResolver` - called on mapper, so it'll mmap index and data file and publish it's addresses to driver.
3. `getReader` - called on a reducer. All the logic to get shuffle blocks.