### PR TITLE
[CORE] Reducer protocol.

### DIFF
--- a/.github/workflows/sparkucx-ci.yml
+++ b/.github/workflows/sparkucx-ci.yml
@@ -10,9 +10,6 @@ on:
 
 jobs:     
   build-sparkucx:
-    strategy:
-      matrix:
-        spark_version: [2.3, 2.4]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -22,8 +19,8 @@ jobs:
         java-version: 1.8
     - name: Build with Maven
       run: mvn -B package -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
-           -Pspark-${{ matrix.spark_version }} --file pom.xml
+           --file pom.xml
     - name: Run Sonar code analysis
-      run: mvn -B sonar:sonar -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dsonar.projectKey=openucx:spark-ucx -Dsonar.organization=openucx -Pspark-${{ matrix.spark_version }} -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=97f4df88ff4fa04e2d5b061acf07315717f1f08b
+      run: mvn -B sonar:sonar -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dsonar.projectKey=openucx:spark-ucx -Dsonar.organization=openucx -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=97f4df88ff4fa04e2d5b061acf07315717f1f08b
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -11,12 +11,6 @@ stages:
   - stage: Build
     jobs:
       - job: build
-        strategy:
-          matrix:
-            spark-2.3:
-              spark_version: "2.3"
-            spark-2.4:
-              spark_version: "2.4"
         pool:
           vmImage: 'ubuntu-16.04'
           demands: Maven
@@ -27,14 +21,14 @@ stages:
               jdkVersionOption: "1.8"
               publishJUnitResults: false
               goals: "package"
-              options: "-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pspark-$(spark_version)"
+              options: "-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
           - task: Maven@3
             displayName: sonar
             inputs:
               jdkVersionOption: "1.8"
               publishJUnitResults: false
               goals: "sonar:sonar"
-              options: "-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dsonar.projectKey=openucx:spark-ucx -Dsonar.organization=openucx -Pspark-$(spark_version) -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=97f4df88ff4fa04e2d5b061acf07315717f1f08b"
+              options: "-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dsonar.projectKey=openucx:spark-ucx -Dsonar.organization=openucx -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=97f4df88ff4fa04e2d5b061acf07315717f1f08b"
           - publish: '$(System.DefaultWorkingDirectory)/'
             artifact: jar for spark-$(spark_version)
             displayName: Publish jars

--- a/pom.xml
+++ b/pom.xml
@@ -35,26 +35,11 @@ See file LICENSE for terms.
     <scala.compat.version>2.11</scala.compat.version>
   </properties>
 
-  <profiles>
-    <profile>
-      <id>spark-2.3</id>
-      <properties>
-        <spark.version>2.3.4</spark.version>
-      </properties>
-    </profile>
-    <profile>
-      <id>spark-2.4</id>
-      <properties>
-        <spark.version>2.4.0</spark.version>
-      </properties>
-    </profile>
-  </profiles>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.compat.version}</artifactId>
-      <version>${spark.version}</version>
+      <version>2.4.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -70,7 +55,17 @@ See file LICENSE for terms.
       <plugin>
         <groupId>net.alchim31.maven</groupId>
         <artifactId>scala-maven-plugin</artifactId>
-        <version>4.2.0</version>
+        <version>4.3.0</version>
+        <configuration>
+          <args>
+            <arg>-Xexperimental</arg>
+            <arg>-Xfatal-warnings</arg>
+            <arg>-explaintypes</arg>
+            <arg>-unchecked</arg>
+            <arg>-deprecation</arg>
+            <arg>-feature</arg>
+          </args>
+        </configuration>
         <executions>
           <execution>
             <id>compile</id>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ See file LICENSE for terms.
   </dependencies>
 
   <build>
-    <finalName>${project.artifactId}-${project.version}-for-spark-${spark.version}</finalName>
+    <finalName>${project.artifactId}-${project.version}-for-spark-2.4</finalName>
     <plugins>
       <plugin>
         <groupId>net.alchim31.maven</groupId>

--- a/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
@@ -116,7 +116,6 @@ public class UcxNode implements Closeable {
 
     RegisteredMemory metadataMemory = memoryPool.get(conf.metadataRPCBufferSize());
     ByteBuffer metadataBuffer = metadataMemory.getBuffer();
-    metadataBuffer.order(ByteOrder.nativeOrder());
     metadataBuffer.putInt(workerAddresss.capacity());
     metadataBuffer.put(workerAddresss);
     try {
@@ -186,7 +185,10 @@ public class UcxNode implements Closeable {
   }
 
   private void stopExecutor() {
-    globalDriverEndpoint.close();
+    if (globalDriverEndpoint != null) {
+      globalDriverEndpoint.close();
+      globalDriverEndpoint = null;
+    }
     allocatedWorkers.forEach(UcxWorkerWrapper::close);
     allocatedWorkers.clear();
   }

--- a/src/main/java/org/apache/spark/shuffle/ucx/memory/RegisteredMemory.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/memory/RegisteredMemory.java
@@ -34,7 +34,7 @@ public class RegisteredMemory {
 
   void deregisterNativeMemory() {
     if (refcount.get() != 0) {
-      logger.warn("De-registering memory that has active references.");
+      logger.warn("De-registering memory of size {} that has active references.", buffer.capacity());
     }
     if (memory != null && memory.getNativeId() != null) {
       memory.deregister();

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/OnBlocksFetchCallback.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/OnBlocksFetchCallback.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.apache.spark.shuffle.ucx.reducer;
+
+import org.apache.spark.network.buffer.ManagedBuffer;
+import org.apache.spark.network.buffer.NioManagedBuffer;
+
+import org.apache.spark.shuffle.ucx.memory.RegisteredMemory;
+import org.apache.spark.storage.ShuffleBlockId;
+import org.apache.spark.util.Utils;
+import org.openucx.jucx.UcxRequest;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Final callback when all blocks fetched.
+ * Notifies Spark's shuffleFetchIterator on block fetch completion.
+ */
+public class OnBlocksFetchCallback extends ReducerCallback {
+  protected RegisteredMemory blocksMemory;
+  protected long[] sizes;
+  private long startTime = System.currentTimeMillis();
+
+  public OnBlocksFetchCallback(ReducerCallback callback, RegisteredMemory blocksMemory, long[] sizes) {
+    super(callback);
+    this.blocksMemory = blocksMemory;
+    this.sizes = sizes;
+  }
+
+  @Override
+  public void onSuccess(UcxRequest request) {
+    logger.info("Fetched {} blocks of total size {} in {}", blockIds.length,
+      Utils.bytesToString(Arrays.stream(sizes).sum()), Utils.getUsedTimeMs(startTime));
+    int position = 0;
+    AtomicInteger refCount = new AtomicInteger(blockIds.length);
+    for (int i = 0; i < blockIds.length; i++) {
+      ShuffleBlockId block = blockIds[i];
+      blocksMemory.getBuffer().position(position).limit(position + (int) sizes[i]);
+      ByteBuffer blockBuffer = blocksMemory.getBuffer().slice();
+      position += (int)sizes[i];
+      listener.onBlockFetchSuccess(block.name(), new NioManagedBuffer(blockBuffer) {
+        @Override
+        public ManagedBuffer release() {
+          if (refCount.decrementAndGet() == 0) {
+            mempool.put(blocksMemory);
+          }
+          return this;
+        }
+      });
+    }
+  }
+}

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/OnOffsetsFetchCallback.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/OnOffsetsFetchCallback.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.apache.spark.shuffle.ucx.reducer;
+
+import org.apache.spark.network.shuffle.BlockFetchingListener;
+import org.apache.spark.shuffle.ucx.memory.RegisteredMemory;
+import org.apache.spark.storage.ShuffleBlockId;
+import org.openucx.jucx.UcxException;
+import org.openucx.jucx.UcxRequest;
+import org.openucx.jucx.UcxUtils;
+import org.openucx.jucx.ucp.UcpEndpoint;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Callback, called when got all offsets for blocks
+ */
+public class OnOffsetsFetchCallback extends ReducerCallback {
+  private final RegisteredMemory offsetMemory;
+  private final long[] dataAddresses;
+
+  public OnOffsetsFetchCallback(ShuffleBlockId[] blockIds, UcpEndpoint endpoint,
+                                UcxShuffleClient client, BlockFetchingListener listener,
+                                RegisteredMemory offsetMemory, long[] dataAddresses) {
+    super(blockIds, endpoint, client, listener);
+    this.offsetMemory = offsetMemory;
+    this.dataAddresses = dataAddresses;
+  }
+
+  @Override
+  public void onSuccess(UcxRequest request) {
+    ByteBuffer resultOffset = offsetMemory.getBuffer();
+    long totalSize = 0;
+    long[] sizes = new long[blockIds.length];
+    for (int i = 0; i < blockIds.length; i++) {
+      long blockOffset = resultOffset.getLong(i * 16);
+      long blockLength = resultOffset.getLong(i * 16 + 8) - blockOffset;
+      sizes[i] = blockLength;
+      totalSize += blockLength;
+      dataAddresses[i] += blockOffset;
+    }
+
+    if (totalSize <= 0 || totalSize >= Integer.MAX_VALUE) {
+      throw new UcxException("Total size: " + totalSize);
+    }
+    mempool.put(offsetMemory);
+    RegisteredMemory blocksMemory = mempool.get((int) totalSize);
+
+    long offset = 0;
+    // Submits N fetch blocks requests
+    for (int i = 0; i < blockIds.length; i++) {
+      endpoint.getNonBlockingImplicit(dataAddresses[i], client.dataRkeysCache.get(blockIds[i].mapId()),
+        UcxUtils.getAddress(blocksMemory.getBuffer()) + offset, sizes[i]);
+      offset += sizes[i];
+    }
+
+    // Process blocks when all fetched.
+    // Flush guarantees that callback would invoke when all fetch requests will completed.
+    endpoint.flushNonBlocking(new OnBlocksFetchCallback(this, blocksMemory, sizes));
+  }
+}

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/ReducerCallback.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/ReducerCallback.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.apache.spark.shuffle.ucx.reducer;
+
+import org.apache.spark.SparkEnv;
+import org.apache.spark.network.shuffle.BlockFetchingListener;
+import org.apache.spark.shuffle.UcxShuffleManager;
+import org.apache.spark.shuffle.ucx.memory.MemoryPool;
+import org.apache.spark.storage.ShuffleBlockId;
+import org.openucx.jucx.UcxCallback;
+import org.openucx.jucx.ucp.UcpEndpoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Common data needed for offset fetch callback and subsequent block fetch callback.
+ */
+public abstract class ReducerCallback extends UcxCallback {
+  protected MemoryPool mempool;
+  protected ShuffleBlockId[] blockIds;
+  protected UcpEndpoint endpoint;
+  protected UcxShuffleClient client;
+  protected BlockFetchingListener listener;
+  protected static final Logger logger = LoggerFactory.getLogger(ReducerCallback.class);
+
+  public ReducerCallback(ShuffleBlockId[] blockIds, UcpEndpoint endpoint,
+                         UcxShuffleClient client, BlockFetchingListener listener) {
+    this.mempool = ((UcxShuffleManager)SparkEnv.get().shuffleManager()).ucxNode().getMemoryPool();
+    this.blockIds = blockIds;
+    this.endpoint = endpoint;
+    this.client = client;
+    this.listener = listener;
+  }
+
+  public ReducerCallback(ReducerCallback callback) {
+    this.blockIds = callback.blockIds;
+    this.client = callback.client;
+    this.endpoint = callback.endpoint;
+    this.listener = callback.listener;
+    this.mempool = callback.mempool;
+  }
+}

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/ReducerCallback.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/ReducerCallback.java
@@ -24,6 +24,7 @@ public abstract class ReducerCallback extends UcxCallback {
   protected UcxShuffleClient client;
   protected BlockFetchingListener listener;
   protected static final Logger logger = LoggerFactory.getLogger(ReducerCallback.class);
+  long startTime = System.currentTimeMillis();
 
   public ReducerCallback(ShuffleBlockId[] blockIds, UcpEndpoint endpoint,
                          UcxShuffleClient client, BlockFetchingListener listener) {
@@ -40,5 +41,6 @@ public abstract class ReducerCallback extends UcxCallback {
     this.endpoint = callback.endpoint;
     this.listener = callback.listener;
     this.mempool = callback.mempool;
+    this.startTime = callback.startTime;
   }
 }

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/UcxShuffleClient.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/UcxShuffleClient.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.apache.spark.shuffle.ucx.reducer;
+
+import org.apache.spark.SparkEnv;
+import org.apache.spark.executor.TempShuffleReadMetrics;
+import org.apache.spark.network.shuffle.BlockFetchingListener;
+import org.apache.spark.network.shuffle.DownloadFileManager;
+import org.apache.spark.network.shuffle.ShuffleClient;
+import org.apache.spark.shuffle.ShuffleHandle;
+import org.apache.spark.shuffle.UcxShuffleManager;
+import org.apache.spark.shuffle.UcxWorkerWrapper;
+import org.apache.spark.shuffle.ucx.memory.MemoryPool;
+import org.apache.spark.shuffle.ucx.memory.RegisteredMemory;
+import org.apache.spark.storage.BlockId$;
+import org.apache.spark.storage.BlockManagerId;
+import org.apache.spark.storage.ShuffleBlockId;
+import org.openucx.jucx.UcxUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.openucx.jucx.UcxException;
+import org.openucx.jucx.ucp.UcpEndpoint;
+import org.openucx.jucx.ucp.UcpRemoteKey;
+import scala.Option;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class UcxShuffleClient extends ShuffleClient {
+  private final MemoryPool mempool;
+  private static final Logger logger = LoggerFactory.getLogger(UcxShuffleClient.class);
+  private final UcxShuffleManager ucxShuffleManager;
+  private final ShuffleHandle handle;
+  private final TempShuffleReadMetrics shuffleReadMetrics;
+  private final UcxWorkerWrapper workerWrapper;
+  final HashMap<Integer, UcpRemoteKey> offsetRkeysCache = new HashMap<>();
+  final HashMap<Integer, UcpRemoteKey> dataRkeysCache = new HashMap<>();
+
+  public UcxShuffleClient(ShuffleHandle handle,
+                          TempShuffleReadMetrics shuffleReadMetrics,
+                          UcxWorkerWrapper workerWrapper) {
+    this.ucxShuffleManager = (UcxShuffleManager) SparkEnv.get().shuffleManager();
+    this.mempool = ucxShuffleManager.ucxNode().getMemoryPool();
+    this.handle = handle;
+    this.shuffleReadMetrics = shuffleReadMetrics;
+    this.workerWrapper = workerWrapper;
+  }
+
+  /**
+   * Submits n non blocking fetch offsets to get needed offsets for n blocks.
+   */
+  private void submitFetchOffsets(UcpEndpoint endpoint, ShuffleBlockId[] blockIds,
+                                  long[] dataAddresses, RegisteredMemory offsetMemory) {
+    ByteBuffer driverMetadata =  workerWrapper.fetchDriverMetadataBuffer(handle.shuffleId()).data();
+    for (int i = 0; i < blockIds.length; i++) {
+      ShuffleBlockId blockId = blockIds[i];
+      // Get block offset
+      int mapIdBlock = blockId.mapId() *
+        (int) ucxShuffleManager.ucxShuffleConf().metadataBlockSize();
+      int offsetWithinBlock = 0;
+      // Parse metadata fetched from driver.
+      long offsetAdress = driverMetadata.getLong(mapIdBlock + offsetWithinBlock);
+      offsetWithinBlock += 8;
+      long dataAddress = driverMetadata.getLong(mapIdBlock + offsetWithinBlock);
+      dataAddresses[i] = dataAddress;
+      offsetWithinBlock += 8;
+
+      // Unpack Rkeys for this workerWrapper
+      if (offsetRkeysCache.get(blockId.mapId()) == null ||
+        dataRkeysCache.get(blockId.mapId()) == null) {
+        int offsetRKeySize = driverMetadata.getInt(mapIdBlock + offsetWithinBlock);
+        offsetWithinBlock += 4;
+        int dataRkeySize = driverMetadata.getInt(mapIdBlock + offsetWithinBlock);
+        offsetWithinBlock += 4;
+
+        if (offsetRKeySize <= 0 || dataRkeySize <= 0) {
+          throw new UcxException("Wrong rkey size.");
+        }
+        final ByteBuffer rkeyCopy = driverMetadata.slice();
+        rkeyCopy.position(mapIdBlock + offsetWithinBlock)
+          .limit(mapIdBlock + offsetWithinBlock + offsetRKeySize);
+
+        offsetWithinBlock += offsetRKeySize;
+
+        offsetRkeysCache.computeIfAbsent(blockId.mapId(), mapId -> endpoint.unpackRemoteKey(rkeyCopy));
+
+        rkeyCopy.position(mapIdBlock + offsetWithinBlock)
+          .limit(mapIdBlock + offsetWithinBlock + dataRkeySize);
+
+        dataRkeysCache.computeIfAbsent(blockId.mapId(), mapId -> endpoint.unpackRemoteKey(rkeyCopy));
+      }
+
+      endpoint.getNonBlockingImplicit(
+        offsetAdress + blockId.reduceId() * 8L, offsetRkeysCache.get(blockId.mapId()),
+        UcxUtils.getAddress(offsetMemory.getBuffer()) + (i * 16), 16);
+    }
+  }
+
+  /**
+   * Reducer entry point. Fetches remote blocks, using 2 ucp_get calls.
+   * This method is inside ShuffleFetchIterator's for loop over hosts.
+   * First fetches block offset from index file, and then fetches block itself.
+   */
+  @Override
+  public void fetchBlocks(String host, int port, String execId,
+                          String[] blockIds, BlockFetchingListener listener,
+                          DownloadFileManager downloadFileManager) {
+    long startTime = System.currentTimeMillis();
+
+    BlockManagerId blockManagerId = BlockManagerId.apply(execId, host, port, Option.empty());
+    UcpEndpoint endpoint = workerWrapper.getConnection(blockManagerId);
+
+    long[] dataAddresses = new long[blockIds.length];
+
+    RegisteredMemory offsetMemory = mempool.get(16 * blockIds.length);
+
+    ShuffleBlockId[] shuffleBlockIds = Arrays.stream(blockIds)
+      .map(blockId -> (ShuffleBlockId)BlockId$.MODULE$.apply(blockId)).toArray(ShuffleBlockId[]::new);
+
+    // Submits N implicit get requests without callback
+    submitFetchOffsets(endpoint, shuffleBlockIds, dataAddresses, offsetMemory);
+
+    // flush guarantees that all that requests completes when callback is called.
+    // TODO: fix https://github.com/openucx/ucx/issues/4267 and use endpoint flush.
+    workerWrapper.worker().flushNonBlocking(
+      new OnOffsetsFetchCallback(shuffleBlockIds, endpoint, this, listener, offsetMemory,
+        dataAddresses));
+    shuffleReadMetrics.incFetchWaitTime(System.currentTimeMillis() - startTime);
+  }
+
+  @Override
+  public void close() {
+    offsetRkeysCache.values().forEach(UcpRemoteKey::close);
+    dataRkeysCache.values().forEach(UcpRemoteKey::close);
+    logger.info("Shuffle read metrics, fetch wait time: {}ms", shuffleReadMetrics.fetchWaitTime());
+  }
+}

--- a/src/main/java/org/apache/spark/shuffle/ucx/rpc/UcxListenerThread.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/rpc/UcxListenerThread.java
@@ -10,7 +10,6 @@ import org.openucx.jucx.UcxRequest;
 import org.openucx.jucx.ucp.UcpWorker;
 
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 
 /**
  * Thread for progressing global worker for connection establishment and RPC exchange.
@@ -35,7 +34,6 @@ public class UcxListenerThread extends Thread implements Runnable {
   private UcxRequest recvRequest() {
     ByteBuffer metadataBuffer = Platform.allocateDirectBuffer(
       ucxNode.getConf().metadataRPCBufferSize());
-    metadataBuffer.order(ByteOrder.nativeOrder());
     RpcConnectionCallback callback = new RpcConnectionCallback(metadataBuffer, isDriver, ucxNode);
     return globalWorker.recvTaggedNonBlocking(metadataBuffer, callback);
   }

--- a/src/main/scala/org/apache/spark/shuffle/UcxShuffleBlockResolver.scala
+++ b/src/main/scala/org/apache/spark/shuffle/UcxShuffleBlockResolver.scala
@@ -103,7 +103,7 @@ class UcxShuffleBlockResolver(ucxShuffleManager: UcxShuffleManager)
     metadataBuffer.clear()
 
     val workerWrapper = ucxShuffleManager.ucxNode.getThreadLocalWorker
-    val driverMetadata = workerWrapper.getDriverMetadataBuffer(shuffleId)
+    val driverMetadata = workerWrapper.getDriverMetadata(shuffleId)
     val driverOffset = driverMetadata.address +
       mapId * ucxShuffleManager.ucxShuffleConf.metadataBlockSize
 
@@ -130,9 +130,9 @@ class UcxShuffleBlockResolver(ucxShuffleManager: UcxShuffleManager)
   def removeShuffle(shuffleId: Int): Unit = {
     logInfo(s"Removing shuffle $shuffleId")
     fileMappings.remove(shuffleId).foreach((mappings: CopyOnWriteArrayList[UcpMemory]) =>
-      mappings.asScala.foreach(unregisterAndUnmap))
+      mappings.asScala.par.foreach(unregisterAndUnmap))
     offsetMappings.remove(shuffleId).foreach((mappings: CopyOnWriteArrayList[UcpMemory]) =>
-      mappings.asScala.foreach(unregisterAndUnmap))
+      mappings.asScala.par.foreach(unregisterAndUnmap))
   }
 
   override def close(): Unit = {

--- a/src/main/scala/org/apache/spark/shuffle/UcxShuffleReader.scala
+++ b/src/main/scala/org/apache/spark/shuffle/UcxShuffleReader.scala
@@ -1,0 +1,145 @@
+/*
+* Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+package org.apache.spark.shuffle
+
+import java.io.InputStream
+import java.util.concurrent.LinkedBlockingQueue
+
+import org.apache.spark.{InterruptibleIterator, MapOutputTracker, SparkEnv, TaskContext}
+import org.apache.spark.internal.{Logging, config}
+import org.apache.spark.serializer.SerializerManager
+import org.apache.spark.shuffle.ucx.reducer.UcxShuffleClient
+import org.apache.spark.storage.{BlockId, BlockManager, ShuffleBlockFetcherIterator}
+import org.apache.spark.util.CompletionIterator
+import org.apache.spark.util.collection.ExternalSorter
+
+/**
+ * Extension of Spark's shuffe reader with a logic of injection UcxShuffleClient,
+ * and lazy progress only when result queue is empty.
+ */
+class UcxShuffleReader[K, C](handle: BaseShuffleHandle[K, _, C],
+  startPartition: Int,
+  endPartition: Int,
+  context: TaskContext,
+  serializerManager: SerializerManager = SparkEnv.get.serializerManager,
+  blockManager: BlockManager = SparkEnv.get.blockManager,
+  mapOutputTracker: MapOutputTracker = SparkEnv.get.mapOutputTracker)
+  extends ShuffleReader[K, C] with Logging {
+
+    private val dep = handle.dependency
+
+    /** Read the combined key-values for this reduce task */
+    override def read(): Iterator[Product2[K, C]] = {
+      val shuffleMetrics = context.taskMetrics().createTempShuffleReadMetrics()
+      val workerWrapper = SparkEnv.get.shuffleManager.asInstanceOf[UcxShuffleManager]
+        .ucxNode.getThreadLocalWorker
+      val shuffleClient = new UcxShuffleClient(handle, shuffleMetrics, workerWrapper)
+      val wrappedStreams = new ShuffleBlockFetcherIterator(
+        context,
+        shuffleClient,
+        blockManager,
+        mapOutputTracker.getMapSizesByExecutorId(handle.shuffleId,
+          startPartition, endPartition),
+        serializerManager.wrapStream,
+        // Note: we use getSizeAsMb when no suffix is provided for backwards compatibility
+        SparkEnv.get.conf.getSizeAsMb("spark.reducer.maxSizeInFlight", "48m") * 1024 * 1024,
+        SparkEnv.get.conf.getInt("spark.reducer.maxReqsInFlight", Int.MaxValue),
+        SparkEnv.get.conf.get(config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS),
+        SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
+        SparkEnv.get.conf.getBoolean("spark.shuffle.detectCorrupt", true))
+
+      // Ucx shuffle logic
+      // Java reflection to get access to private results queue
+      val queueField = wrappedStreams.getClass.getDeclaredField(
+        "org$apache$spark$storage$ShuffleBlockFetcherIterator$$results")
+      queueField.setAccessible(true)
+      val resultQueue = queueField.get(wrappedStreams).asInstanceOf[LinkedBlockingQueue[_]]
+
+      // Do progress if queue is empty before calling next on ShuffleIterator
+      val ucxWrappedStream = new Iterator[(BlockId, InputStream)] {
+        override def next(): (BlockId, InputStream) = {
+          val startTime = System.currentTimeMillis()
+          workerWrapper.progressRequests(resultQueue)
+          shuffleMetrics.incFetchWaitTime(System.currentTimeMillis() - startTime)
+          wrappedStreams.next()
+        }
+
+        override def hasNext: Boolean = {
+          val result = wrappedStreams.hasNext
+          if (!result) {
+            shuffleClient.close()
+          }
+          result
+        }
+      }
+      // End of ucx shuffle logic
+
+      val serializerInstance = dep.serializer.newInstance()
+      val recordIter = ucxWrappedStream.flatMap { case (blockId, wrappedStream) =>
+        // Note: the asKeyValueIterator below wraps a key/value iterator inside of a
+        // NextIterator. The NextIterator makes sure that close() is called on the
+        // underlying InputStream when all records have been read.
+        serializerInstance.deserializeStream(wrappedStream).asKeyValueIterator
+      }
+
+      // Update the context task metrics for each record read.
+      val readMetrics = context.taskMetrics.createTempShuffleReadMetrics()
+      val metricIter = CompletionIterator[(Any, Any), Iterator[(Any, Any)]](
+        recordIter.map { record =>
+          readMetrics.incRecordsRead(1)
+          record
+        },
+        context.taskMetrics().mergeShuffleReadMetrics())
+
+      // An interruptible iterator must be used here in order to support task cancellation
+      val interruptibleIter = new InterruptibleIterator[(Any, Any)](context, metricIter)
+
+      val aggregatedIter: Iterator[Product2[K, C]] = if (dep.aggregator.isDefined) {
+        if (dep.mapSideCombine) {
+          // We are reading values that are already combined
+          val combinedKeyValuesIterator = interruptibleIter.asInstanceOf[Iterator[(K, C)]]
+          dep.aggregator.get.combineCombinersByKey(combinedKeyValuesIterator, context)
+        } else {
+          // We don't know the value type, but also don't care -- the dependency *should*
+          // have made sure its compatible w/ this aggregator, which will convert the value
+          // type to the combined type C
+          val keyValuesIterator = interruptibleIter.asInstanceOf[Iterator[(K, Nothing)]]
+          dep.aggregator.get.combineValuesByKey(keyValuesIterator, context)
+        }
+      } else {
+        interruptibleIter.asInstanceOf[Iterator[Product2[K, C]]]
+      }
+
+      // Sort the output if there is a sort ordering defined.
+      val resultIter = dep.keyOrdering match {
+        case Some(keyOrd: Ordering[K]) =>
+          // Create an ExternalSorter to sort the data.
+          val sorter =
+            new ExternalSorter[K, C, C](context,
+              ordering = Some(keyOrd), serializer = dep.serializer)
+          sorter.insertAll(aggregatedIter)
+          context.taskMetrics().incMemoryBytesSpilled(sorter.memoryBytesSpilled)
+          context.taskMetrics().incDiskBytesSpilled(sorter.diskBytesSpilled)
+          context.taskMetrics().incPeakExecutionMemory(sorter.peakMemoryUsedBytes)
+          // Use completion callback to stop sorter if task was finished/cancelled.
+          context.addTaskCompletionListener[Unit](_ => {
+            sorter.stop()
+          })
+          CompletionIterator[Product2[K, C],
+            Iterator[Product2[K, C]]](sorter.iterator, sorter.stop())
+        case None =>
+          aggregatedIter
+      }
+
+      resultIter match {
+        case _: InterruptibleIterator[Product2[K, C]] => resultIter
+        case _ =>
+          // Use another interruptible iterator here to support task cancellation as aggregator
+          // or(and) sorter may have consumed previous interruptible iterator.
+          new InterruptibleIterator[Product2[K, C]](context, resultIter)
+      }
+    }
+
+}

--- a/src/main/scala/org/apache/spark/shuffle/UcxShuffleReader.scala
+++ b/src/main/scala/org/apache/spark/shuffle/UcxShuffleReader.scala
@@ -61,7 +61,7 @@ class UcxShuffleReader[K, C](handle: BaseShuffleHandle[K, _, C],
       val ucxWrappedStream = new Iterator[(BlockId, InputStream)] {
         override def next(): (BlockId, InputStream) = {
           val startTime = System.currentTimeMillis()
-          workerWrapper.progressRequests(resultQueue)
+          workerWrapper.fillQueueWithBlocks(resultQueue)
           shuffleMetrics.incFetchWaitTime(System.currentTimeMillis() - startTime)
           wrappedStreams.next()
         }


### PR DESCRIPTION
Reducer protocol - where all the acceleration happens. 
1. UcxShuffleManager instantiates UcxShuffleReader that instantiates UcxShuffleClient and doing progress.
2. UcxShuffleClient implements `fetchBlocks` that's doing 2 consecutive ucp_get operations:
2.1. Fetch offset (`OnOffsetsFetchCallback`)
2.2. Fetch blocks (`OnBlocksFetchCallback`)
3. Removed spark-2.3 support, since this version is not supported by apache anymore.