### PR TITLE
[CORE] Update to jucx-1.8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@ See file LICENSE for terms.
     <dependency>
       <groupId>org.openucx</groupId>
       <artifactId>jucx</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 
@@ -105,10 +105,10 @@ See file LICENSE for terms.
 
   <repositories>
     <repository>
-      <id>Maven</id>
-      <url>https://pkgs.dev.azure.com/ucfconsort/sparkucx/_packaging/Maven/maven/v1</url>
+      <id>oss.sonatype.org-snapshot</id>
+      <url>http://oss.sonatype.org/content/repositories/snapshots</url>
       <releases>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
       </releases>
       <snapshots>
         <enabled>true</enabled>
@@ -116,16 +116,4 @@ See file LICENSE for terms.
     </repository>
   </repositories>
 
-  <distributionManagement>
-    <repository>
-      <id>Maven</id>
-      <url>https://pkgs.dev.azure.com/ucfconsort/sparkucx/_packaging/Maven/maven/v1</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </distributionManagement>
 </project>

--- a/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
@@ -14,14 +14,12 @@ import org.apache.spark.shuffle.ucx.rpc.UcxListenerThread;
 import org.apache.spark.storage.BlockManagerId;
 import org.openucx.jucx.UcxCallback;
 import org.openucx.jucx.UcxException;
-import org.openucx.jucx.UcxRequest;
 import org.openucx.jucx.ucp.*;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -140,7 +138,7 @@ public class UcxNode implements Closeable {
     // TODO: send using stream API when it would be available in jucx.
     globalDriverEndpoint.sendTaggedNonBlocking(metadataMemory.getBuffer(), new UcxCallback() {
       @Override
-      public void onSuccess(UcxRequest request) {
+      public void onSuccess(UcpRequest request) {
         memoryPool.put(metadataMemory);
       }
     });

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/OnBlocksFetchCallback.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/OnBlocksFetchCallback.java
@@ -10,7 +10,7 @@ import org.apache.spark.network.buffer.NioManagedBuffer;
 import org.apache.spark.shuffle.ucx.memory.RegisteredMemory;
 import org.apache.spark.storage.ShuffleBlockId;
 import org.apache.spark.util.Utils;
-import org.openucx.jucx.UcxRequest;
+import org.openucx.jucx.ucp.UcpRequest;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -31,7 +31,7 @@ public class OnBlocksFetchCallback extends ReducerCallback {
   }
 
   @Override
-  public void onSuccess(UcxRequest request) {
+  public void onSuccess(UcpRequest request) {
     logger.info("Endpoint {} fetched {} blocks of total size {} in {}", endpoint.getNativeId(), blockIds.length,
       Utils.bytesToString(Arrays.stream(sizes).sum()), Utils.getUsedTimeMs(startTime));
     int position = 0;

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/OnOffsetsFetchCallback.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/OnOffsetsFetchCallback.java
@@ -7,9 +7,9 @@ package org.apache.spark.shuffle.ucx.reducer;
 import org.apache.spark.network.shuffle.BlockFetchingListener;
 import org.apache.spark.shuffle.ucx.memory.RegisteredMemory;
 import org.apache.spark.storage.ShuffleBlockId;
-import org.openucx.jucx.UcxRequest;
 import org.openucx.jucx.UcxUtils;
 import org.openucx.jucx.ucp.UcpEndpoint;
+import org.openucx.jucx.ucp.UcpRequest;
 
 import java.nio.ByteBuffer;
 
@@ -29,7 +29,7 @@ public class OnOffsetsFetchCallback extends ReducerCallback {
   }
 
   @Override
-  public void onSuccess(UcxRequest request) {
+  public void onSuccess(UcpRequest request) {
     ByteBuffer resultOffset = offsetMemory.getBuffer();
     long totalSize = 0;
     int[] sizes = new int[blockIds.length];

--- a/src/main/scala/org/apache/spark/shuffle/UcxShuffleConf.scala
+++ b/src/main/scala/org/apache/spark/shuffle/UcxShuffleConf.scala
@@ -85,4 +85,6 @@ class UcxShuffleConf(conf: SparkConf) extends SparkConf {
     .booleanConf.createWithDefault(true)
 
   lazy val preregisterMemory: Boolean = conf.getBoolean(PREREGISTER_MEMORY.key, PREREGISTER_MEMORY.defaultValue.get)
+
+  lazy val useOdp: Boolean = conf.getBoolean(getUcxConf("memory.useOdp"), false)
 }

--- a/src/main/scala/org/apache/spark/shuffle/UcxWorkerWrapper.scala
+++ b/src/main/scala/org/apache/spark/shuffle/UcxWorkerWrapper.scala
@@ -12,8 +12,8 @@ import java.util.concurrent.{ConcurrentHashMap, LinkedBlockingQueue}
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
-import org.openucx.jucx.{UcxException, UcxRequest}
-import org.openucx.jucx.ucp.{UcpEndpoint, UcpEndpointParams, UcpRemoteKey, UcpWorker}
+import org.openucx.jucx.UcxException
+import org.openucx.jucx.ucp.{UcpEndpoint, UcpEndpointParams, UcpRemoteKey, UcpRequest, UcpWorker}
 import org.apache.spark.SparkEnv
 import org.apache.spark.internal.Logging
 import org.apache.spark.shuffle.ucx.UcxNode
@@ -98,11 +98,9 @@ class UcxWorkerWrapper(val worker: UcpWorker, val conf: UcxShuffleConf, val id: 
   /**
    * Blocking progress single request until it's not completed.
    */
-  def waitRequest(request: UcxRequest): Unit = {
+  def waitRequest(request: UcpRequest): Unit = {
     val startTime = System.currentTimeMillis()
-    while (!request.isCompleted) {
-      progress()
-    }
+    worker.progressRequest(request)
     logDebug(s"Request completed in ${Utils.getUsedTimeMs(startTime)}")
   }
 


### PR DESCRIPTION
1. Update SparkUCX to use the latest 1.8.0-SNAPSHOT jucx jar. 
2. Change memory pool to allocate and register in 1 call using `UcpMemMapParams.allocate` flag.
3. Cancel outstanding recv request.

TODO: add connectionHandler support 