### PR TITLE
[CORE] use ucx from hpcx module, disable mt workers.

### DIFF
--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -33,7 +33,7 @@ stages:
               options: "-B  -Dmaven.repo.local=$(System.DefaultWorkingDirectory)/target/.deps -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Pspark-$(profile_version)"
           - bash: |
               set -xeE
-              module load tools/spark-$(spark_version)
+              module load tools/spark-$(spark_version) hpcx-gcc
               source buildlib/test.sh
 
               if [[ $(get_rdma_device_iface) != "" ]]
@@ -41,6 +41,7 @@ stages:
                 export SPARK_UCX_JAR=$(System.DefaultWorkingDirectory)/target/spark-ucx-1.0-for-spark-$(profile_version)-jar-with-dependencies.jar
                 export SPARK_LOCAL_DIRS=$(System.DefaultWorkingDirectory)/target/spark
                 export SPARK_VERSION=$(spark_version)
+                export UCX_LIB=$HPCX_UCX_DIR/lib
                 cd $(System.DefaultWorkingDirectory)/target/
                 run_tests
               else

--- a/buildlib/test.sh
+++ b/buildlib/test.sh
@@ -139,6 +139,8 @@ setup_configuration() {
 	EOF
 
     cp ${SPARK_HOME}/conf/log4j.properties.template ${SPARK_CONF_DIR}/log4j.properties
+    sed -i -e 's/INFO/WARN/g' ${SPARK_CONF_DIR}/log4j.properties
+    echo "log4j.logger.org.apache.spark.shuffle=DEBUG" >> ${SPARK_CONF_DIR}/log4j.properties
 }
 
 start_cluster() {

--- a/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
@@ -36,7 +36,7 @@ public class UcxNode implements Closeable {
   private final boolean isDriver;
   private final UcpContext context;
   private final MemoryPool memoryPool;
-  private final UcpWorkerParams workerParams = new UcpWorkerParams().requestThreadSafety();
+  private final UcpWorkerParams workerParams = new UcpWorkerParams();
   private final UcpWorker globalWorker;
   private final UcxShuffleConf conf;
   // Mapping from spark's entity of BlockManagerId to UcxEntity workerAddress.


### PR DESCRIPTION
Use ucx as a module to speed up testing time, and disable `requestThreadSafety` from worker params.