### PR TITLE
[CORE] Spark-3.0 reducer protocol.

### DIFF
--- a/.github/workflows/sparkucx-ci.yml
+++ b/.github/workflows/sparkucx-ci.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:     
   build-sparkucx:
+    strategy:
+      matrix:
+        spark_version: [2.4, 3.0]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -21,6 +24,6 @@ jobs:
       run: mvn -B package -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
            --file pom.xml
     - name: Run Sonar code analysis
-      run: mvn -B sonar:sonar -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dsonar.projectKey=openucx:spark-ucx -Dsonar.organization=openucx -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=97f4df88ff4fa04e2d5b061acf07315717f1f08b
+      run: mvn -B sonar:sonar -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dsonar.projectKey=openucx:spark-ucx -Dsonar.organization=openucx -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=97f4df88ff4fa04e2d5b061acf07315717f1f08b -Pspark-${{ matrix.spark_version }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/buildlib/test.sh
+++ b/buildlib/test.sh
@@ -119,6 +119,7 @@ setup_configuration() {
 
     cat <<-EOF > ${SPARK_CONF_DIR}/spark-defaults.conf
 	spark.shuffle.manager org.apache.spark.shuffle.UcxShuffleManager
+	spark.shuffle.sort.io.plugin.class org.apache.spark.shuffle.compat.spark_3_0.UcxLocalDiskShuffleDataIO
 	spark.shuffle.readHostLocalDisk.enabled false
 	spark.driver.extraClassPath ${SPARK_UCX_JAR}:${UCX_LIB}
 	spark.executor.extraClassPath ${SPARK_UCX_JAR}:${UCX_LIB}

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@ See file LICENSE for terms.
     <dependency>
       <groupId>org.openucx</groupId>
       <artifactId>jucx</artifactId>
-      <version>1.8.0-SNAPSHOT</version>
+      <version>1.9.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@ See file LICENSE for terms.
       <properties>
         <spark.version>2.4.0</spark.version>
         <project.excludes>**/spark_3_0/**</project.excludes>
+        <sonar.exclusions>**/spark_3_0/**</sonar.exclusions>
         <scala.version>2.11.12</scala.version>
         <scala.compat.version>2.11</scala.compat.version>
       </properties>
@@ -53,6 +54,7 @@ See file LICENSE for terms.
         <scala.version>2.12.10</scala.version>
         <scala.compat.version>2.12</scala.compat.version>
         <project.excludes>**/spark_2_4/**</project.excludes>
+        <sonar.exclusions>**/spark_2_4/**</sonar.exclusions>
       </properties>
     </profile>
   </profiles>

--- a/src/main/java/org/apache/spark/shuffle/ucx/UnsafeUtils.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/UnsafeUtils.java
@@ -26,6 +26,9 @@ public class UnsafeUtils {
 
   private static final Constructor<?> directBufferConstructor;
 
+  public static final int LONG_SIZE = 8;
+  public static final int INT_SIZE = 4;
+
   static {
     try {
       mmap = FileChannelImpl.class.getDeclaredMethod("map0", int.class, long.class, long.class);

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_2_4/UcxShuffleClient.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_2_4/UcxShuffleClient.java
@@ -10,6 +10,7 @@ import org.apache.spark.network.shuffle.BlockFetchingListener;
 import org.apache.spark.network.shuffle.DownloadFileManager;
 import org.apache.spark.network.shuffle.ShuffleClient;
 import org.apache.spark.shuffle.*;
+import org.apache.spark.shuffle.ucx.UnsafeUtils;
 import org.apache.spark.shuffle.ucx.memory.MemoryPool;
 import org.apache.spark.shuffle.ucx.memory.RegisteredMemory;
 import org.apache.spark.storage.BlockId;
@@ -61,10 +62,10 @@ public class UcxShuffleClient extends ShuffleClient {
         endpoint.unpackRemoteKey(driverMetadata.dataRkey(blockId.mapId())));
 
       endpoint.getNonBlockingImplicit(
-        offsetAddress + blockId.reduceId() * UcxWorkerWrapper.LONG_SIZE(),
+        offsetAddress + blockId.reduceId() * UnsafeUtils.LONG_SIZE,
           offsetRkeysCache.get(blockId.mapId()),
-        UcxUtils.getAddress(offsetMemory.getBuffer()) + (i * 2L * UcxWorkerWrapper.LONG_SIZE()),
-        2L * UcxWorkerWrapper.LONG_SIZE());
+        UcxUtils.getAddress(offsetMemory.getBuffer()) + (i * 2L * UnsafeUtils.LONG_SIZE),
+        2L * UnsafeUtils.LONG_SIZE);
     }
   }
 
@@ -85,7 +86,7 @@ public class UcxShuffleClient extends ShuffleClient {
     long[] dataAddresses = new long[blockIds.length];
 
     // Need to fetch 2 long offsets current block + next block to calculate exact block size.
-    RegisteredMemory offsetMemory = mempool.get(2 * UcxWorkerWrapper.LONG_SIZE() * blockIds.length);
+    RegisteredMemory offsetMemory = mempool.get(2 * UnsafeUtils.LONG_SIZE * blockIds.length);
 
     ShuffleBlockId[] shuffleBlockIds = Arrays.stream(blockIds)
       .map(blockId -> (ShuffleBlockId) BlockId.apply(blockId)).toArray(ShuffleBlockId[]::new);

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_3_0/OnOffsetsFetchCallback.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_3_0/OnOffsetsFetchCallback.java
@@ -6,6 +6,7 @@ package org.apache.spark.shuffle.ucx.reducer.compat.spark_3_0;
 
 import org.apache.spark.network.shuffle.BlockFetchingListener;
 import org.apache.spark.shuffle.UcxWorkerWrapper;
+import org.apache.spark.shuffle.ucx.UnsafeUtils;
 import org.apache.spark.shuffle.ucx.memory.RegisteredMemory;
 import org.apache.spark.shuffle.ucx.reducer.ReducerCallback;
 import org.apache.spark.shuffle.ucx.reducer.OnBlocksFetchCallback;
@@ -48,13 +49,14 @@ public class OnOffsetsFetchCallback extends ReducerCallback {
     int offset = 0;
     long blockOffset;
     long blockLength;
-
+    int offsetSize = UnsafeUtils.LONG_SIZE;
     for (int i = 0; i < blockIds.length; i++) {
+      // Blocks in metadata buffer are in form | blockOffsetStart | blockOffsetEnd |
       if (blockIds[i] instanceof ShuffleBlockBatchId) {
         ShuffleBlockBatchId blockBatchId = (ShuffleBlockBatchId) blockIds[i];
         int blocksInBatch = blockBatchId.endReduceId() - blockBatchId.startReduceId();
-        blockOffset = resultOffset.getLong(offset * 16);
-        blockLength = resultOffset.getLong(offset * 16 + UcxWorkerWrapper.LONG_SIZE() * blocksInBatch)
+        blockOffset = resultOffset.getLong(offset * 2 * offsetSize);
+        blockLength = resultOffset.getLong(offset * 2 * offsetSize + offsetSize * blocksInBatch)
           - blockOffset;
         offset += blocksInBatch;
       } else {
@@ -63,7 +65,7 @@ public class OnOffsetsFetchCallback extends ReducerCallback {
         offset++;
       }
 
-      assert (blockLength > 0) && (blockLength < Integer.MAX_VALUE);
+      assert (blockLength > 0) && (blockLength <= Integer.MAX_VALUE);
       sizes[i] = (int) blockLength;
       totalSize += blockLength;
       dataAddresses[i] += blockOffset;

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_3_0/OnOffsetsFetchCallback.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_3_0/OnOffsetsFetchCallback.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+ * See file LICENSE for terms.
+ */
+package org.apache.spark.shuffle.ucx.reducer.compat.spark_3_0;
+
+import org.apache.spark.network.shuffle.BlockFetchingListener;
+import org.apache.spark.shuffle.UcxWorkerWrapper;
+import org.apache.spark.shuffle.ucx.memory.RegisteredMemory;
+import org.apache.spark.shuffle.ucx.reducer.ReducerCallback;
+import org.apache.spark.shuffle.ucx.reducer.OnBlocksFetchCallback;
+import org.apache.spark.storage.BlockId;
+import org.apache.spark.storage.ShuffleBlockBatchId;
+import org.apache.spark.storage.ShuffleBlockId;
+import org.openucx.jucx.UcxUtils;
+import org.openucx.jucx.ucp.UcpEndpoint;
+import org.openucx.jucx.ucp.UcpRemoteKey;
+import org.openucx.jucx.ucp.UcpRequest;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+/**
+ * Callback, called when got all offsets for blocks
+ */
+public class OnOffsetsFetchCallback extends ReducerCallback {
+  private final RegisteredMemory offsetMemory;
+  private final long[] dataAddresses;
+  private Map<Integer, UcpRemoteKey> dataRkeysCache;
+  private final Map<Long, Integer> mapId2PartitionId;
+
+  public OnOffsetsFetchCallback(BlockId[] blockIds, UcpEndpoint endpoint, BlockFetchingListener listener,
+                                RegisteredMemory offsetMemory, long[] dataAddresses,
+                                Map<Integer, UcpRemoteKey> dataRkeysCache,
+                                Map<Long, Integer> mapId2PartitionId) {
+    super(blockIds, endpoint, listener);
+    this.offsetMemory = offsetMemory;
+    this.dataAddresses = dataAddresses;
+    this.dataRkeysCache = dataRkeysCache;
+    this.mapId2PartitionId = mapId2PartitionId;
+  }
+
+  @Override
+  public void onSuccess(UcpRequest request) {
+    ByteBuffer resultOffset = offsetMemory.getBuffer();
+    long totalSize = 0;
+    int[] sizes = new int[blockIds.length];
+    int offset = 0;
+    long blockOffset;
+    long blockLength;
+
+    for (int i = 0; i < blockIds.length; i++) {
+      if (blockIds[i] instanceof ShuffleBlockBatchId) {
+        ShuffleBlockBatchId blockBatchId = (ShuffleBlockBatchId) blockIds[i];
+        int blocksInBatch = blockBatchId.endReduceId() - blockBatchId.startReduceId();
+        blockOffset = resultOffset.getLong(offset * 16);
+        blockLength = resultOffset.getLong(offset * 16 + UcxWorkerWrapper.LONG_SIZE() * blocksInBatch)
+          - blockOffset;
+        offset += blocksInBatch;
+      } else {
+        blockOffset = resultOffset.getLong(offset * 16);
+        blockLength = resultOffset.getLong(offset * 16 + 8) - blockOffset;
+        offset++;
+      }
+
+      assert (blockLength > 0) && (blockLength < Integer.MAX_VALUE);
+      sizes[i] = (int) blockLength;
+      totalSize += blockLength;
+      dataAddresses[i] += blockOffset;
+    }
+
+    assert  (totalSize > 0) &&  (totalSize < Integer.MAX_VALUE);
+    mempool.put(offsetMemory);
+    RegisteredMemory blocksMemory = mempool.get((int) totalSize);
+
+    offset = 0;
+    // Submits N fetch blocks requests
+    for (int i = 0; i < blockIds.length; i++) {
+      int mapPartitionId = (blockIds[i] instanceof ShuffleBlockId) ?
+        mapId2PartitionId.get(((ShuffleBlockId)blockIds[i]).mapId()) :
+        mapId2PartitionId.get(((ShuffleBlockBatchId)blockIds[i]).mapId());
+      endpoint.getNonBlockingImplicit(dataAddresses[i], dataRkeysCache.get(mapPartitionId),
+        UcxUtils.getAddress(blocksMemory.getBuffer()) + offset, sizes[i]);
+      offset += sizes[i];
+    }
+
+    // Process blocks when all fetched.
+    // Flush guarantees that callback would invoke when all fetch requests will completed.
+    endpoint.flushNonBlocking(new OnBlocksFetchCallback(this, blocksMemory, sizes));
+  }
+}

--- a/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_3_0/UcxShuffleClient.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/reducer/compat/spark_3_0/UcxShuffleClient.java
@@ -4,21 +4,132 @@
  */
 package org.apache.spark.shuffle.ucx.reducer.compat.spark_3_0;
 
+import org.apache.spark.SparkEnv;
+import org.apache.spark.executor.TempShuffleReadMetrics;
 import org.apache.spark.network.shuffle.BlockFetchingListener;
 import org.apache.spark.network.shuffle.BlockStoreClient;
 import org.apache.spark.network.shuffle.DownloadFileManager;
+import org.apache.spark.shuffle.DriverMetadata;
+import org.apache.spark.shuffle.UcxShuffleManager;
+import org.apache.spark.shuffle.UcxWorkerWrapper;
+import org.apache.spark.shuffle.ucx.memory.RegisteredMemory;
+import org.apache.spark.storage.*;
+import org.openucx.jucx.UcxUtils;
+import org.openucx.jucx.ucp.UcpEndpoint;
+import org.openucx.jucx.ucp.UcpRemoteKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Option;
 
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class UcxShuffleClient extends BlockStoreClient {
+  private static final Logger logger = LoggerFactory.getLogger(UcxShuffleClient.class);
+  private final UcxWorkerWrapper workerWrapper;
+  private final Map<Long, Integer> mapId2PartitionId;
+  private final TempShuffleReadMetrics shuffleReadMetrics;
+  private final int shuffleId;
+  final HashMap<Integer, UcpRemoteKey> offsetRkeysCache = new HashMap<>();
+  final HashMap<Integer, UcpRemoteKey> dataRkeysCache = new HashMap<>();
 
-  @Override
-  public void close() {
-    throw new UnsupportedOperationException("TODO");
+
+  public UcxShuffleClient(int shuffleId, UcxWorkerWrapper workerWrapper,
+                          Map<Long, Integer> mapId2PartitionId,  TempShuffleReadMetrics shuffleReadMetrics) {
+    this.workerWrapper = workerWrapper;
+    this.shuffleId = shuffleId;
+    this.mapId2PartitionId = mapId2PartitionId;
+    this.shuffleReadMetrics = shuffleReadMetrics;
+  }
+
+  /**
+   * Submits n non blocking fetch offsets to get needed offsets for n blocks.
+   */
+  private void submitFetchOffsets(UcpEndpoint endpoint, BlockId[] blockIds,
+                                  RegisteredMemory offsetMemory,
+                                  long[] dataAddresses) {
+    DriverMetadata driverMetadata =  workerWrapper.fetchDriverMetadataBuffer(shuffleId);
+    long offset = 0;
+    int startReduceId;
+    long size;
+
+    for (int i = 0; i < blockIds.length; i++) {
+      BlockId blockId = blockIds[i];
+      int mapIdpartition;
+
+      if (blockId instanceof ShuffleBlockId) {
+        ShuffleBlockId shuffleBlockId = (ShuffleBlockId) blockId;
+        mapIdpartition = mapId2PartitionId.get(shuffleBlockId.mapId());
+        size = 2L * UcxWorkerWrapper.LONG_SIZE();
+        startReduceId = shuffleBlockId.reduceId();
+      } else {
+        ShuffleBlockBatchId shuffleBlockBatchId = (ShuffleBlockBatchId) blockId;
+        mapIdpartition = mapId2PartitionId.get(shuffleBlockBatchId.mapId());
+        size = (shuffleBlockBatchId.endReduceId() - shuffleBlockBatchId.startReduceId())
+          * 2L * UcxWorkerWrapper.LONG_SIZE();
+        startReduceId = shuffleBlockBatchId.startReduceId();
+      }
+
+      long offsetAddress = driverMetadata.offsetAddress(mapIdpartition);
+      dataAddresses[i] = driverMetadata.dataAddress(mapIdpartition);
+
+      offsetRkeysCache.computeIfAbsent(mapIdpartition, mapId ->
+        endpoint.unpackRemoteKey(driverMetadata.offsetRkey(mapIdpartition)));
+
+      dataRkeysCache.computeIfAbsent(mapIdpartition, mapId ->
+        endpoint.unpackRemoteKey(driverMetadata.dataRkey(mapIdpartition)));
+
+      endpoint.getNonBlockingImplicit(
+        offsetAddress + startReduceId * UcxWorkerWrapper.LONG_SIZE(),
+        offsetRkeysCache.get(mapIdpartition),
+        UcxUtils.getAddress(offsetMemory.getBuffer()) + offset,
+        size);
+
+      offset += size;
+    }
   }
 
   @Override
   public void fetchBlocks(String host, int port, String execId, String[] blockIds, BlockFetchingListener listener,
                           DownloadFileManager downloadFileManager) {
-    throw new UnsupportedOperationException("TODO");
+    long startTime = System.currentTimeMillis();
+    BlockManagerId blockManagerId = BlockManagerId.apply(execId, host, port, Option.empty());
+    UcpEndpoint endpoint = workerWrapper.getConnection(blockManagerId);
+    long[] dataAddresses = new long[blockIds.length];
+    int totalBlocks = 0;
+
+    BlockId[] blocks = new BlockId[blockIds.length];
+
+    for (int i=0; i < blockIds.length; i++) {
+      blocks[i] = BlockId.apply(blockIds[i]);
+      if (blocks[i] instanceof ShuffleBlockId) {
+        totalBlocks += 1;
+      } else {
+        ShuffleBlockBatchId blockBatchId = (ShuffleBlockBatchId)blocks[i];
+        totalBlocks += (blockBatchId.endReduceId() - blockBatchId.startReduceId());
+      }
+    }
+
+    RegisteredMemory offsetMemory = ((UcxShuffleManager)SparkEnv.get().shuffleManager())
+      .ucxNode().getMemoryPool().get(totalBlocks * 2 * UcxWorkerWrapper.LONG_SIZE());
+    // Submits N implicit get requests without callback
+    submitFetchOffsets(endpoint, blocks, offsetMemory, dataAddresses);
+
+    // flush guarantees that all that requests completes when callback is called.
+    // TODO: fix https://github.com/openucx/ucx/issues/4267 and use endpoint flush.
+    workerWrapper.worker().flushNonBlocking(
+      new OnOffsetsFetchCallback(blocks, endpoint, listener, offsetMemory,
+        dataAddresses, dataRkeysCache, mapId2PartitionId));
+
+    shuffleReadMetrics.incFetchWaitTime(System.currentTimeMillis() - startTime);
   }
+
+  @Override
+  public void close() {
+    offsetRkeysCache.values().forEach(UcpRemoteKey::close);
+    dataRkeysCache.values().forEach(UcpRemoteKey::close);
+    logger.info("Shuffle read metrics, fetch wait time: {}ms", shuffleReadMetrics.fetchWaitTime());
+  }
+
 }

--- a/src/main/scala/org/apache/spark/shuffle/CommonUcxShuffleBlockResolver.scala
+++ b/src/main/scala/org/apache/spark/shuffle/CommonUcxShuffleBlockResolver.scala
@@ -50,7 +50,7 @@ abstract class CommonUcxShuffleBlockResolver(ucxShuffleManager: CommonUcxShuffle
     }
     val dataMemory = ucxShuffleManager.ucxNode.getContext.memoryMap(memMapParams)
     fileMappings(shuffleId).add(dataMemory)
-    assume(indexBackFile.length() == UcxWorkerWrapper.LONG_SIZE * (lengths.length + 1))
+    assume(indexBackFile.length() == UnsafeUtils.LONG_SIZE * (lengths.length + 1))
 
     val offsetAddress = UnsafeUtils.mmap(indexFileChannel, 0, indexBackFile.length())
     memMapParams.setAddress(offsetAddress).setLength(indexBackFile.length())
@@ -70,8 +70,8 @@ abstract class CommonUcxShuffleBlockResolver(ucxShuffleManager: CommonUcxShuffle
     val metadataBuffer = metadataRegisteredMemory.getBuffer.slice()
 
     if (metadataBuffer.remaining() > ucxShuffleManager.ucxShuffleConf.metadataBlockSize) {
-      throw new SparkException(s"Metadata block size ${metadataBuffer.remaining()} " +
-        s"is greater then configured 2 * ${ucxShuffleManager.ucxShuffleConf.RKEY_SIZE.key}" +
+      throw new SparkException(s"Metadata block size ${metadataBuffer.remaining() / 2} " +
+        s"is greater then configured ${ucxShuffleManager.ucxShuffleConf.RKEY_SIZE.key}" +
         s"(${ucxShuffleManager.ucxShuffleConf.metadataBlockSize}).")
     }
 

--- a/src/main/scala/org/apache/spark/shuffle/CommonUcxShuffleBlockResolver.scala
+++ b/src/main/scala/org/apache/spark/shuffle/CommonUcxShuffleBlockResolver.scala
@@ -4,7 +4,7 @@
 */
 package org.apache.spark.shuffle
 
-import java.io.{Closeable, File, RandomAccessFile}
+import java.io.{File, RandomAccessFile}
 import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList}
 
 import scala.collection.JavaConverters._

--- a/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleManager.scala
@@ -7,7 +7,7 @@ package org.apache.spark.shuffle
 import scala.collection.JavaConverters._
 
 import org.apache.spark.shuffle.api.ShuffleExecutorComponents
-import org.apache.spark.shuffle.compat.spark_3_0.UcxShuffleBlockResolver
+import org.apache.spark.shuffle.compat.spark_3_0.{UcxShuffleBlockResolver, UcxShuffleReader}
 import org.apache.spark.shuffle.sort.{SerializedShuffleHandle, SortShuffleWriter, UnsafeShuffleWriter}
 import org.apache.spark.util.ShutdownHookManager
 import org.apache.spark.{ShuffleDependency, SparkConf, SparkEnv, TaskContext}
@@ -55,8 +55,8 @@ class UcxShuffleManager(override val conf: SparkConf, isDriver: Boolean) extends
 
     startUcxNodeIfMissing()
     shuffleIdToHandle.putIfAbsent(handle.shuffleId, handle.asInstanceOf[UcxShuffleHandle[K, _, C]])
-    super.getReader(handle.asInstanceOf[UcxShuffleHandle[K,_,C]].baseHandle,
-      startPartition, endPartition, context, metrics)
+    new UcxShuffleReader(handle.asInstanceOf[UcxShuffleHandle[K,_,C]], startPartition, endPartition,
+      context, readMetrics = metrics, shouldBatchFetch = true)
   }
 
 

--- a/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleReader.scala
+++ b/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleReader.scala
@@ -1,0 +1,190 @@
+/*
+* Copyright (C) Mellanox Technologies Ltd. 2019. ALL RIGHTS RESERVED.
+* See file LICENSE for terms.
+*/
+package org.apache.spark.shuffle.compat.spark_3_0
+
+import java.io.InputStream
+import java.util.concurrent.LinkedBlockingQueue
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.internal.{Logging, config}
+import org.apache.spark.io.CompressionCodec
+import org.apache.spark.serializer.SerializerManager
+import org.apache.spark.shuffle.ucx.reducer.compat.spark_3_0.UcxShuffleClient
+import org.apache.spark.shuffle.{ShuffleReadMetricsReporter, ShuffleReader, UcxShuffleHandle, UcxShuffleManager}
+import org.apache.spark.storage.{BlockId, BlockManager, ShuffleBlockBatchId, ShuffleBlockFetcherIterator, ShuffleBlockId}
+import org.apache.spark.util.CompletionIterator
+import org.apache.spark.util.collection.ExternalSorter
+import org.apache.spark.{InterruptibleIterator, SparkEnv, SparkException, TaskContext}
+
+
+/**
+ * Extension of Spark's shuffe reader with a logic of injection UcxShuffleClient,
+ * and lazy progress only when result queue is empty.
+ */
+class UcxShuffleReader[K, C](handle: UcxShuffleHandle[K, _, C],
+                             startPartition: Int,
+                             endPartition: Int,
+                             context: TaskContext,
+                             serializerManager: SerializerManager = SparkEnv.get.serializerManager,
+                             blockManager: BlockManager = SparkEnv.get.blockManager,
+                             readMetrics: ShuffleReadMetricsReporter,
+                             shouldBatchFetch: Boolean = false)
+  extends ShuffleReader[K, C] with Logging {
+
+    private val dep = handle.baseHandle.dependency
+
+  /** Read the combined key-values for this reduce task */
+    override def read(): Iterator[Product2[K, C]] = {
+      val (blocksByAddressIterator1, blocksByAddressIterator2) = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(
+        handle.shuffleId, startPartition, endPartition).duplicate
+      val mapIdToBlockIndex = blocksByAddressIterator2.flatMap{
+        case (_, blocks) => blocks.map {
+          case (blockId, _, mapIdx) => blockId match {
+            case x: ShuffleBlockId =>  (x.mapId.asInstanceOf[java.lang.Long], mapIdx.asInstanceOf[java.lang.Integer])
+            case x: ShuffleBlockBatchId => (x.mapId.asInstanceOf[java.lang.Long], mapIdx.asInstanceOf[java.lang.Integer])
+            case _ => throw new SparkException("Unknown block")
+          }
+        }
+      }.toMap
+
+      val workerWrapper = SparkEnv.get.shuffleManager.asInstanceOf[UcxShuffleManager]
+        .ucxNode.getThreadLocalWorker
+      val shuffleMetrics = context.taskMetrics().createTempShuffleReadMetrics()
+      val shuffleClient = new UcxShuffleClient(handle.shuffleId, workerWrapper, mapIdToBlockIndex.asJava, shuffleMetrics)
+      val shuffleIterator = new ShuffleBlockFetcherIterator(
+        context,
+        shuffleClient,
+        blockManager,
+        blocksByAddressIterator1,
+        serializerManager.wrapStream,
+        // Note: we use getSizeAsMb when no suffix is provided for backwards compatibility
+        SparkEnv.get.conf.get(config.REDUCER_MAX_SIZE_IN_FLIGHT) * 1024 * 1024,
+        SparkEnv.get.conf.get(config.REDUCER_MAX_REQS_IN_FLIGHT),
+        SparkEnv.get.conf.get(config.REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS),
+        SparkEnv.get.conf.get(config.MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
+        SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT),
+        SparkEnv.get.conf.get(config.SHUFFLE_DETECT_CORRUPT_MEMORY),
+        readMetrics,
+        fetchContinuousBlocksInBatch)
+
+      val wrappedStreams = shuffleIterator.toCompletionIterator
+
+      // Ucx shuffle logic
+      // Java reflection to get access to private results queue
+      val queueField = shuffleIterator.getClass.getDeclaredField(
+        "org$apache$spark$storage$ShuffleBlockFetcherIterator$$results")
+      queueField.setAccessible(true)
+      val resultQueue = queueField.get(shuffleIterator).asInstanceOf[LinkedBlockingQueue[_]]
+
+      // Do progress if queue is empty before calling next on ShuffleIterator
+      val ucxWrappedStream = new Iterator[(BlockId, InputStream)] {
+        override def next(): (BlockId, InputStream) = {
+          val startTime = System.currentTimeMillis()
+          workerWrapper.fillQueueWithBlocks(resultQueue)
+          readMetrics.incFetchWaitTime(System.currentTimeMillis() - startTime)
+          wrappedStreams.next()
+        }
+
+        override def hasNext: Boolean = {
+          val result = wrappedStreams.hasNext
+          if (!result) {
+            shuffleClient.close()
+          }
+          result
+        }
+      }
+      // End of ucx shuffle logic
+
+      val serializerInstance = dep.serializer.newInstance()
+      
+      // Create a key/value iterator for each stream
+      val recordIter = ucxWrappedStream.flatMap { case (blockId, wrappedStream) =>
+        // Note: the asKeyValueIterator below wraps a key/value iterator inside of a
+        // NextIterator. The NextIterator makes sure that close() is called on the
+        // underlying InputStream when all records have been read.
+        serializerInstance.deserializeStream(wrappedStream).asKeyValueIterator
+      }
+
+      // Update the context task metrics for each record read.
+      val metricIter = CompletionIterator[(Any, Any), Iterator[(Any, Any)]](
+        recordIter.map { record =>
+          readMetrics.incRecordsRead(1)
+          record
+        },
+        context.taskMetrics().mergeShuffleReadMetrics())
+
+      // An interruptible iterator must be used here in order to support task cancellation
+      val interruptibleIter = new InterruptibleIterator[(Any, Any)](context, metricIter)
+
+      val aggregatedIter: Iterator[Product2[K, C]] = if (dep.aggregator.isDefined) {
+        if (dep.mapSideCombine) {
+          // We are reading values that are already combined
+          val combinedKeyValuesIterator = interruptibleIter.asInstanceOf[Iterator[(K, C)]]
+          dep.aggregator.get.combineCombinersByKey(combinedKeyValuesIterator, context)
+        } else {
+          // We don't know the value type, but also don't care -- the dependency *should*
+          // have made sure its compatible w/ this aggregator, which will convert the value
+          // type to the combined type C
+          val keyValuesIterator = interruptibleIter.asInstanceOf[Iterator[(K, Nothing)]]
+          dep.aggregator.get.combineValuesByKey(keyValuesIterator, context)
+        }
+      } else {
+        interruptibleIter.asInstanceOf[Iterator[Product2[K, C]]]
+      }
+
+      // Sort the output if there is a sort ordering defined.
+      val resultIter = dep.keyOrdering match {
+        case Some(keyOrd: Ordering[K]) =>
+          // Create an ExternalSorter to sort the data.
+          val sorter =
+            new ExternalSorter[K, C, C](context, ordering = Some(keyOrd), serializer = dep.serializer)
+          sorter.insertAll(aggregatedIter)
+          context.taskMetrics().incMemoryBytesSpilled(sorter.memoryBytesSpilled)
+          context.taskMetrics().incDiskBytesSpilled(sorter.diskBytesSpilled)
+          context.taskMetrics().incPeakExecutionMemory(sorter.peakMemoryUsedBytes)
+          // Use completion callback to stop sorter if task was finished/cancelled.
+          context.addTaskCompletionListener[Unit](_ => {
+            sorter.stop()
+          })
+          CompletionIterator[Product2[K, C], Iterator[Product2[K, C]]](sorter.iterator, sorter.stop())
+        case None =>
+          aggregatedIter
+      }
+
+      resultIter match {
+        case _: InterruptibleIterator[Product2[K, C]] => resultIter
+        case _ =>
+          // Use another interruptible iterator here to support task cancellation as aggregator
+          // or(and) sorter may have consumed previous interruptible iterator.
+          new InterruptibleIterator[Product2[K, C]](context, resultIter)
+      }
+    }
+
+  private def fetchContinuousBlocksInBatch: Boolean = {
+    val conf = SparkEnv.get.conf
+    val serializerRelocatable = dep.serializer.supportsRelocationOfSerializedObjects
+    val compressed = conf.get(config.SHUFFLE_COMPRESS)
+    val codecConcatenation = if (compressed) {
+      CompressionCodec.supportsConcatenationOfSerializedStreams(CompressionCodec.createCodec(conf))
+    } else {
+      true
+    }
+    val useOldFetchProtocol = conf.get(config.SHUFFLE_USE_OLD_FETCH_PROTOCOL)
+
+    val doBatchFetch = shouldBatchFetch && serializerRelocatable &&
+      (!compressed || codecConcatenation) && !useOldFetchProtocol
+    if (shouldBatchFetch && !doBatchFetch) {
+      logWarning("The feature tag of continuous shuffle block fetching is set to true, but " +
+        "we can not enable the feature because other conditions are not satisfied. " +
+        s"Shuffle compress: $compressed, serializer ${dep.serializer.getClass.getName} " +
+        s"relocatable: $serializerRelocatable, " +
+        s"codec concatenation: $codecConcatenation, use old shuffle fetch protocol: " +
+        s"$useOldFetchProtocol.")
+    }
+    doBatchFetch
+  }
+
+}

--- a/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleReader.scala
+++ b/src/main/scala/org/apache/spark/shuffle/compat/spark_3_0/UcxShuffleReader.scala
@@ -31,12 +31,11 @@ class UcxShuffleReader[K, C](handle: UcxShuffleHandle[K, _, C],
                              serializerManager: SerializerManager = SparkEnv.get.serializerManager,
                              blockManager: BlockManager = SparkEnv.get.blockManager,
                              readMetrics: ShuffleReadMetricsReporter,
-                             shouldBatchFetch: Boolean = false)
-  extends ShuffleReader[K, C] with Logging {
+                             shouldBatchFetch: Boolean = false) extends ShuffleReader[K, C] with Logging {
 
     private val dep = handle.baseHandle.dependency
 
-  /** Read the combined key-values for this reduce task */
+    /** Read the combined key-values for this reduce task */
     override def read(): Iterator[Product2[K, C]] = {
       val (blocksByAddressIterator1, blocksByAddressIterator2) = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(
         handle.shuffleId, startPartition, endPartition).duplicate


### PR DESCRIPTION
Spark-3.0 reducer protocol that handles `ShuffleBlockBatchId` blocks, that has type (mapId, startReduceId, endReduceId). Also handles translation from MapId -> BlockIdx, bacuse mapId now unique long, while we need integer offset.