### PR TITLE
Avoid get lock from synchronized in every shuffle

### DIFF
--- a/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
+++ b/src/main/java/org/apache/spark/shuffle/ucx/UcxNode.java
@@ -110,12 +110,12 @@ public class UcxNode implements Closeable {
    */
   private RegisteredMemory buildMetadataBuffer() {
     BlockManagerId blockManagerId = SparkEnv.get().blockManager().blockManagerId();
-    ByteBuffer workerAddresss = globalWorker.getAddress();
+    ByteBuffer workerAddresses = globalWorker.getAddress();
 
     RegisteredMemory metadataMemory = memoryPool.get(conf.metadataRPCBufferSize());
     ByteBuffer metadataBuffer = metadataMemory.getBuffer();
-    metadataBuffer.putInt(workerAddresss.capacity());
-    metadataBuffer.put(workerAddresss);
+    metadataBuffer.putInt(workerAddresses.capacity());
+    metadataBuffer.put(workerAddresses);
     try {
       SerializableBlockManagerID.serializeBlockManagerID(blockManagerId, metadataBuffer);
     } catch (IOException e) {

--- a/src/main/scala/org/apache/spark/shuffle/CommonUcxShuffleManager.scala
+++ b/src/main/scala/org/apache/spark/shuffle/CommonUcxShuffleManager.scala
@@ -64,9 +64,11 @@ abstract class CommonUcxShuffleManager(val conf: SparkConf, isDriver: Boolean) e
   /**
    * Atomically starts UcxNode singleton - one for all shuffle threads.
    */
-  def startUcxNodeIfMissing(): Unit = synchronized {
-    if (ucxNode == null) {
-      ucxNode = new UcxNode(ucxShuffleConf, isDriver)
+  def startUcxNodeIfMissing(): Unit = if (ucxNode == null) {
+    synchronized {
+      if (ucxNode == null) {
+        ucxNode = new UcxNode(ucxShuffleConf, isDriver)
+      }
     }
   }
 

--- a/src/main/scala/org/apache/spark/shuffle/UcxWorkerWrapper.scala
+++ b/src/main/scala/org/apache/spark/shuffle/UcxWorkerWrapper.scala
@@ -127,14 +127,14 @@ class UcxWorkerWrapper(val worker: UcpWorker, val conf: UcxShuffleConf, val id: 
   }
 
   def getConnection(blockManagerId: BlockManagerId): UcpEndpoint = {
-    val workerAdresses = UcxNode.getWorkerAddresses
+    val workerAddresses = UcxNode.getWorkerAddresses
     // Block untill there's no worker address for this BlockManagerID
     val startTime = System.currentTimeMillis()
     val timeout = conf.getTimeAsMs("spark.network.timeout", "100")
-    if (workerAdresses.get(blockManagerId) == null) {
-      workerAdresses.synchronized {
-        while (workerAdresses.get(blockManagerId) == null) {
-          workerAdresses.wait(timeout)
+    if (workerAddresses.get(blockManagerId) == null) {
+      workerAddresses.synchronized {
+        while (workerAddresses.get(blockManagerId) == null) {
+          workerAddresses.wait(timeout)
           if (System.currentTimeMillis() - startTime > timeout) {
             throw new UcxException(s"Didn't get worker address for $blockManagerId during $timeout")
           }
@@ -146,7 +146,7 @@ class UcxWorkerWrapper(val worker: UcpWorker, val conf: UcxShuffleConf, val id: 
       logInfo(s"Worker $id connecting to $blockManagerId")
       val endpointParams = new UcpEndpointParams()
         .setPeerErrorHandlingMode()
-        .setUcpAddress(workerAdresses.get(blockManagerId))
+        .setUcpAddress(workerAddresses.get(blockManagerId))
      worker.newEndpoint(endpointParams)
     })
   }


### PR DESCRIPTION
1.get lock to init `UcxNode` only in the first shuffle
2.fix typo